### PR TITLE
Translate UI text to i18next

### DIFF
--- a/frontend/src/components/ActionSheet.jsx
+++ b/frontend/src/components/ActionSheet.jsx
@@ -11,7 +11,7 @@ function ActionSheet({ actions, buttonSize }) {
       const rect = buttonRef.current.getBoundingClientRect();
       setPosition({
         top: rect.bottom + window.scrollY,
-        left: rect.right - 192, // largeur estimée du menu
+        left: rect.right - 192, // estimated menu width
       });
     }
     setShow(!show);
@@ -33,7 +33,7 @@ function ActionSheet({ actions, buttonSize }) {
 
   return (
     <>
-      {/* pas de background */}
+      {/* no background */}
       <button className={`btn btn-outline-dark ${buttonSize === 'sm' ? 'btn-sm' : ''}`} ref={buttonRef} onClick={toggleDropdown}>
         <i className="bi bi-three-dots-vertical"></i>
       </button>

--- a/frontend/src/components/AlertSystem.jsx
+++ b/frontend/src/components/AlertSystem.jsx
@@ -15,7 +15,7 @@ function AlertSystem({
 
   useEffect(() => {
     if (!message) return;
-    setVisible(true); // déclenche l'animation d'apparition
+    setVisible(true); // trigger fade-in animation
 
     if (!isConfirm) {
       const timer = setTimeout(() => {

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -150,7 +150,7 @@ function Footer() {
         </div>
       </div>
 
-      {/* Style pour le hover souligné */}
+      {/* Underline on hover */}
       <style>{`
         .link-hover:hover {
           text-decoration: underline;

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -396,8 +396,8 @@ function Navbar({ sharedProps }) {
                         <li>
                           <button
                             className="dropdown-item"
-                            aria-label="Déconnexion"
-                            title="Déconnexion"
+                            aria-label={t('logout')}
+                            title={t('logout')}
                             onClick={handleLogout}
                           >
                             <i className="bi bi-unlock fs-5 me-2"></i>{' '}

--- a/frontend/src/components/RealtimeManager.jsx
+++ b/frontend/src/components/RealtimeManager.jsx
@@ -32,7 +32,7 @@ export default function RealtimeManager({
     location.pathname.startsWith(route)
   );
 
-  // ✅ Appel des hooks (OK car toujours dans un composant monté dans <Router>)
+// ✅ Hooks call (safe since component is mounted within <Router>)
   useRealtimeCalendars(
     isRealtimeEnabled ? setCalendarsData : null,
     setLoadingStates

--- a/frontend/src/components/ShareCalendarModal.jsx
+++ b/frontend/src/components/ShareCalendarModal.jsx
@@ -442,10 +442,10 @@ const ShareCalendarModal = forwardRef(
     const handleCopyLink = async (link) => {
       try {
         await navigator.clipboard.writeText(link);
-        triggerAlert('success', 'Lien copié !');
+        triggerAlert('success', t('link_copied'));
         ref?.current?.close();
       } catch {
-        triggerAlert('danger', 'Erreur lors de la copie du lien.');
+        triggerAlert('danger', t('copy_link_error'));
       }
     };
 
@@ -474,7 +474,7 @@ const ShareCalendarModal = forwardRef(
           );
           triggerAlert('success', rep.message);
         } catch {
-          triggerAlert('danger', 'Erreur lors de la copie du lien.');
+          triggerAlert('danger', t('copy_link_error'));
         }
       } else {
         triggerAlert('danger', rep.error);

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -151,5 +151,18 @@
   "share_calendar": "Share calendar",
   "link": "Link",
   "share": "Share",
+  "link_copied": "Link copied!",
+  "copy_link_error": "Error copying the link.",
+  "previous_day": "Previous day",
+  "next_day": "Next day",
+  "no_events_today": "No events today.",
   "loading_share": "Loading sharing..."
+  "invalid_reset_link": "Invalid or expired reset link.",
+  "invalid_session": "Invalid session. Please request a new link.",
+  "session_change_error": "Unable to change password: invalid session.",
+  "password_updated": "Your password has been updated.",
+  "new_password": "New password",
+  "new_password_desc": "Enter a new password for your MediTime account.",
+  "saving": "Saving...",
+  "save_password": "Save password"
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -151,7 +151,17 @@
   "share_calendar": "Partager le calendrier",
   "link": "Lien",
   "share": "Partager",
+  "link_copied": "Lien copié !",
+  "copy_link_error": "Erreur lors de la copie du lien.",
   "previous_day": "Jour précédente",
   "next_day": "Jour suivante",
   "no_events_today": "Aucun événement ce jour-là."
+  "invalid_reset_link": "Lien de réinitialisation invalide ou expiré.",
+  "invalid_session": "Session invalide. Merci de redemander un lien.",
+  "session_change_error": "Impossible de modifier le mot de passe : session invalide.",
+  "password_updated": "Votre mot de passe a bien été modifié.",
+  "new_password": "Nouveau mot de passe",
+  "new_password_desc": "Saisissez un nouveau mot de passe pour votre compte MediTime.",
+  "saving": "Enregistrement...",
+  "save_password": "Enregistrer le mot de passe"
 }

--- a/frontend/src/pages/ResetPasswordConfirm.jsx
+++ b/frontend/src/pages/ResetPasswordConfirm.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { supabase } from '../services/supabaseClient';
 import AlertSystem from '../components/AlertSystem';
 import { log } from '../utils/logger';
@@ -11,6 +12,7 @@ export default function ResetPasswordConfirm() {
   const [loading, setLoading] = useState(false);
   const [sessionReady, setSessionReady] = useState(false);
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   useEffect(() => {
     const initSession = async () => {
@@ -23,7 +25,7 @@ export default function ResetPasswordConfirm() {
           origin: 'RESET_PASSWORD_CONFIRM',
         });
         setAlertType('danger');
-        setAlertMessage("Lien de réinitialisation invalide ou expiré.");
+        setAlertMessage(t('invalid_reset_link'));
         return;
       }
   
@@ -34,7 +36,7 @@ export default function ResetPasswordConfirm() {
           origin: 'RESET_PASSWORD_CONFIRM',
         });
         setAlertType('danger');
-        setAlertMessage("Session invalide. Merci de redemander un lien.");
+        setAlertMessage(t('invalid_session'));
         return;
       }
   
@@ -44,7 +46,7 @@ export default function ResetPasswordConfirm() {
   
       if (!session || !session.user) {
         setAlertType('danger');
-        setAlertMessage("Session invalide. Merci de redemander un lien.");
+        setAlertMessage(t('invalid_session'));
         return;
       }
   
@@ -65,7 +67,7 @@ export default function ResetPasswordConfirm() {
 
     if (!sessionReady) {
       setAlertType('danger');
-      setAlertMessage("Impossible de modifier le mot de passe : session invalide.");
+      setAlertMessage(t('session_change_error'));
       setLoading(false);
       return;
     }
@@ -79,7 +81,7 @@ export default function ResetPasswordConfirm() {
       setAlertMessage(error.message);
     } else {
       setAlertType('success');
-      setAlertMessage("Votre mot de passe a bien été modifié.");
+      setAlertMessage(t('password_updated'));
       setTimeout(() => navigate('/login'), 2500);
     }
 
@@ -90,9 +92,9 @@ export default function ResetPasswordConfirm() {
     <div className="container d-flex justify-content-center align-items-center my-5">
       <div className="card shadow" style={{ maxWidth: '500px', width: '100%', borderRadius: '1rem' }}>
         <div className="card-body p-4">
-          <h5 className="text-center mb-3">🔐 Nouveau mot de passe</h5>
+          <h5 className="text-center mb-3">🔐 {t('new_password')}</h5>
           <p className="text-muted text-center">
-            Saisissez un nouveau mot de passe pour votre compte MediTime.
+            {t('new_password_desc')}
           </p>
           <AlertSystem
             type={alertType}
@@ -101,7 +103,7 @@ export default function ResetPasswordConfirm() {
           />
           <form onSubmit={handleSubmit}>
             <div className="mb-3">
-              <label htmlFor="password" className="form-label">Nouveau mot de passe</label>
+              <label htmlFor="password" className="form-label">{t('new_password')}</label>
               <input
                 type="password"
                 id="password"
@@ -116,7 +118,7 @@ export default function ResetPasswordConfirm() {
               className="btn btn-primary w-100"
               disabled={loading || !sessionReady}
             >
-              {loading ? "Enregistrement..." : "Enregistrer le mot de passe"}
+              {loading ? t('saving') : t('save_password')}
             </button>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- convert some French UI text to i18next keys
- add missing translation keys for English and French
- translate password reset page text
- minor English comments

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f7b06794832880437fc38fc08fa2