### PR TITLE
Internationalize settings page

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -151,5 +151,10 @@
   "share_calendar": "Share calendar",
   "link": "Link",
   "share": "Share",
-  "loading_share": "Loading sharing..."
+  "loading_share": "Loading sharing...",
+  "my_account": "My account",
+  "security": "Security",
+  "preferences": "Preferences",
+  "reset_password": "Reset password",
+  "reset_password_email_sent": "A password reset email has been sent to your email address."
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -153,5 +153,10 @@
   "share": "Partager",
   "previous_day": "Jour précédente",
   "next_day": "Jour suivante",
-  "no_events_today": "Aucun événement ce jour-là."
+  "no_events_today": "Aucun événement ce jour-là.",
+  "my_account": "Mon compte",
+  "security": "Sécurité",
+  "preferences": "Préférences",
+  "reset_password": "Réinitialiser le mot de passe",
+  "reset_password_email_sent": "Un email de réinitialisation a été envoyé à votre adresse email."
 }

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -6,10 +6,12 @@ import { Link, useLocation } from 'react-router-dom';
 import { handleLogout, resetPassword } from '../services/authService';
 import { UserContext } from '../contexts/UserContext';
 import AlertSystem from '../components/AlertSystem';
+import { useTranslation } from 'react-i18next';
 
 const SettingsPage = ({ sharedProps }) => {
   const location = useLocation();
   const { userInfo } = useContext(UserContext);
+  const { t } = useTranslation();
   const [alertType, setAlertType] = useState('');
   const [alertMessage, setAlertMessage] = useState('');
   const [showAlert, setShowAlert] = useState(false);
@@ -46,54 +48,54 @@ const SettingsPage = ({ sharedProps }) => {
         <div className="col-md-3 mb-3">
           <div className="card shadow-sm rounded">
             <div className="card-body p-3">
-              <h5 className="mb-3">Paramètres</h5>
+              <h5 className="mb-3">{t('settings')}</h5>
               <div className="nav flex-column nav-pills">
                 <Link
                   className={`nav-link text-start ${activeTab === 'account' ? 'active' : ''}`}
                   to="/settings?tab=account"
                 >
-                  <i className="bi bi-person me-2"></i> Mon compte
+                  <i className="bi bi-person me-2"></i> {t('my_account')}
                 </Link>
                 <Link
                   className={`nav-link text-start ${activeTab === 'security' ? 'active' : ''}`}
                   to="/settings?tab=security"
                 >
-                  <i className="bi bi-shield-lock me-2"></i> Sécurité
+                  <i className="bi bi-shield-lock me-2"></i> {t('security')}
                 </Link>
                 <Link
                   className={`nav-link text-start ${activeTab === 'notifications' ? 'active' : ''}`}
                   to="/settings?tab=notifications"
                 >
-                  <i className="bi bi-bell me-2"></i> Notifications
+                  <i className="bi bi-bell me-2"></i> {t('notifications')}
                 </Link>
                 <Link
                   className={`nav-link text-start ${activeTab === 'preferences' ? 'active' : ''}`}
                   to="/settings?tab=preferences"
                 >
-                  <i className="bi bi-sliders me-2"></i> Préférences
+                  <i className="bi bi-sliders me-2"></i> {t('preferences')}
                 </Link>
                 <hr />
                 <button
-                  aria-label="Déconnexion"
-                  title="Déconnexion"
+                  aria-label={t('logout')}
+                  title={t('logout')}
                   onClick={handleLogout}
                   className='btn btn-outline-primary text-start nav-link text-start'
                 >
-                  <i className="bi bi-unlock fs-5 me-2"></i> Déconnexion
+                  <i className="bi bi-unlock fs-5 me-2"></i> {t('logout')}
                 </button>
                 {showAlert && <AlertSystem type={alertType} message={alertMessage} />}
                 <button
-                  aria-label="Réinitialiser le mot de passe"
-                  title="Réinitialiser le mot de passe"
+                  aria-label={t('reset_password')}
+                  title={t('reset_password')}
                   onClick={() => {
                     resetPassword(userInfo.email);
                     setAlertType('success');
-                    setAlertMessage('Un email de réinitialisation a été envoyé à votre adresse email.');
+                    setAlertMessage(t('reset_password_email_sent'));
                     setShowAlert(true);
                   }}
                   className='btn btn-outline-primary text-start nav-link text-start'
                 >
-                  <i className="bi bi-envelope fs-5 me-2"></i> Réinitialiser le mot de passe
+                  <i className="bi bi-envelope fs-5 me-2"></i> {t('reset_password')}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- use i18next in settings page
- add translation keys for settings page strings

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f87cbe488328ba7f58f8e2ba556f