### PR TITLE
Fix translation hook usage

### DIFF
--- a/frontend/src/pages/BoxesView.jsx
+++ b/frontend/src/pages/BoxesView.jsx
@@ -302,6 +302,7 @@ function BoxCard({
   setDose,
   dose,
 }) {
+  const { t } = useTranslation();
   const editable = selectedModifyBox === box.id;
   const timeOfDayMap = {
     morning: t('morning'),
@@ -757,6 +758,7 @@ function BoxField({
 }
 
 function StockBadge({ box }) {
+  const { t } = useTranslation();
   if (box.box_capacity === 0) return null;
 
   if (box.stock_quantity <= 0) {
@@ -791,6 +793,7 @@ function InputDropdown({
   onChangeStockQuantity,
   fetchSuggestions,
 }) {
+  const { t } = useTranslation();
   const [suggestions, setSuggestions] = useState([]);
   const [showDropdown, setShowDropdown] = useState(false);
   const inputRef = useRef();

--- a/frontend/src/pages/SharedList.jsx
+++ b/frontend/src/pages/SharedList.jsx
@@ -377,6 +377,7 @@ function TokenList({
   selectedModifyCalendar,
   setSelectedModifyCalendar,
 }) {
+  const { t } = useTranslation();
   return (
     <ul className="list-group">
       <h6 className="">{t("public_links")}:</h6>
@@ -574,6 +575,7 @@ function UserList({
   emailsToInvite,
   setEmailsToInvite,
 }) {
+  const { t } = useTranslation();
   return (
     <ul className="list-group">
       <h6>{t("shared_users")}:</h6>


### PR DESCRIPTION
## Summary
- initialize the translation hook in `BoxCard`, `StockBadge`, and `InputDropdown` components
- use the translation hook in `TokenList` and `UserList`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868507079ac83288d49f68985ff5f48