### PR TITLE
Fix status logging format

### DIFF
--- a/backend/app/auth/fcm.py
+++ b/backend/app/auth/fcm.py
@@ -22,12 +22,12 @@ def get_fcm_access_token():
         return credentials_obj.token, project_id
     except Exception as e:
         log_backend.error(
-            f"Erreur lors du refresh du token FCM : {e}",
+            "erreur refresh token FCM",
             {
                 "origin": "FCM",
                 "code": "FCM_TOKEN_REFRESH_ERROR",
-                "error": traceback.format_exc()
-            }
+                "error": traceback.format_exc(),
+            },
         )
         return None, None
 
@@ -60,25 +60,25 @@ def send_fcm_notification(tokens, title, body, json_body):
 
         response = requests.post(url, headers=headers, json=payload)
         log_backend.info(
-            f"send_fcm_notification : {response.status_code}", 
+            "envoi notification FCM",
             {
-                "origin": "FCM", 
-                "code": "FCM_SEND_NOTIFICATION", 
+                "origin": "FCM",
+                "code": "FCM_SEND_NOTIFICATION",
                 "status_code": response.status_code,
                 "token": token,
                 "title": title,
-            }
+            },
         )
         try:
             data = response.json()
         except Exception as e:
             log_backend.error(
-                f"Erreur send_fcm_notification : {e}", 
+                "erreur envoi FCM",
                 {
-                    "origin": "FCM", 
-                    "code": "FCM_ERROR", 
-                    "error": traceback.format_exc()
-                }
+                    "origin": "FCM",
+                    "code": "FCM_ERROR",
+                    "error": traceback.format_exc(),
+                },
             )
             data = response.text
 

--- a/backend/app/auth/google_services.py
+++ b/backend/app/auth/google_services.py
@@ -15,30 +15,35 @@ def init_firebase():
     """Initialise Firebase Admin SDK à partir du JSON dans l'env."""
     try:
         if firebase_admin._apps:
-            log_backend.info("Firebase déjà initialisé", {"origin": "FIREBASE_INIT"})
+            log_backend.info(
+                "firebase déjà initialisé",
+                {"origin": "FIREBASE_INIT", "code": "FIREBASE_INIT_ALREADY"},
+            )
             return
 
         service_account_raw = Config.GOOGLE_APPLICATION_CREDENTIALS
 
         if not service_account_raw:
-            log_backend.error("Aucune clé de service Firebase trouvée dans .env", {
-                "origin": "FIREBASE_INIT"
-            })
+            log_backend.error(
+                "clé de service firebase manquante",
+                {"origin": "FIREBASE_INIT", "code": "FIREBASE_INIT_MISSING"},
+            )
             raise RuntimeError("GOOGLE_APPLICATION_CREDENTIALS manquant")
 
         service_account_dict = json.loads(service_account_raw)
         
         cred = credentials.Certificate(service_account_dict)
         firebase_admin.initialize_app(cred)
-        log_backend.info("Firebase initialisé avec succès", {
-            "origin": "FIREBASE_INIT"
-        })
+        log_backend.info(
+            "firebase initialisé",
+            {"origin": "FIREBASE_INIT", "code": "FIREBASE_INIT_SUCCESS"},
+        )
         
     except Exception as e:
-        log_backend.error("Erreur lors de l'initialisation de Firebase", {
-            "origin": "FIREBASE_INIT",
-            "error": str(e)
-        })
+        log_backend.error(
+            "erreur initialisation firebase",
+            {"origin": "FIREBASE_INIT", "code": "FIREBASE_INIT_ERROR", "error": str(e)},
+        )
         raise RuntimeError("Initialisation Firebase échouée")
 
 
@@ -59,18 +64,21 @@ def init_vertex_ai():
             credentials=credentials
         )
 
-        log_backend.info("Vertex AI initialisé avec succès", {
-            "origin": "VERTEX_INIT",
-            "project": project_id,
-            "location": location
-        })
+        log_backend.info(
+            "vertex ai initialisé",
+            {
+                "origin": "VERTEX_INIT",
+                "code": "VERTEX_INIT_SUCCESS",
+                "project": project_id,
+                "location": location,
+            },
+        )
 
     except Exception as e:
-        log_backend.error("Erreur lors de l'initialisation de Vertex AI", {
-            "origin": "VERTEX_INIT",
-            "code": "VERTEX_INIT_ERROR",
-            "error": str(e)
-        })
+        log_backend.error(
+            "erreur initialisation vertex ai",
+            {"origin": "VERTEX_INIT", "code": "VERTEX_INIT_ERROR", "error": str(e)},
+        )
         raise RuntimeError("Initialisation Vertex AI échouée")
 
 
@@ -89,11 +97,11 @@ def get_google_credentials(scopes):
 
     except Exception as e:
         log_backend.error(
-            f"Erreur get_google_credentials : {e}",
+            "erreur get_google_credentials",
             {
                 "origin": "AUTH",
                 "code": "GOOGLE_CREDENTIALS_ERROR",
-                "error": traceback.format_exc()
-            }
+                "error": traceback.format_exc(),
+            },
         )
         return None, None

--- a/backend/app/cron/scheduler.py
+++ b/backend/app/cron/scheduler.py
@@ -12,7 +12,10 @@ def run_scheduler():
     # toute les 10 secondes
     #schedule.every(10).seconds.do(decrease_stock)
 
-    log_backend.info("⏳ [CRON] Test : cron toutes les jours initialisé")
+    log_backend.info(
+        "cron démarré",
+        {"origin": "CRON", "code": "CRON_START"},
+    )
 
     while True:
         schedule.run_pending()

--- a/backend/app/cron/tasks/stock.py
+++ b/backend/app/cron/tasks/stock.py
@@ -34,7 +34,13 @@ def decrease_stock():
                     check_low_stock_and_notify_for_calendar(calendar_id)
 
             conn.commit()
-        log_backend.info("✅ Fin de la diminution des stocks", {"origin": "CRON", "code": "STOCK_DECREASE_SUCCESS"})
+        log_backend.info(
+            "diminution des stocks terminée",
+            {"origin": "CRON", "code": "STOCK_DECREASE_SUCCESS"},
+        )
 
     except Exception as e:
-        log_backend.error(f"Erreur lors de la diminution des stocks: {e}", {"origin": "CRON", "code": "STOCK_DECREASE_ERROR", "error": str(e)})
+        log_backend.error(
+            "erreur diminution des stocks",
+            {"origin": "CRON", "code": "STOCK_DECREASE_ERROR", "error": str(e)},
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         print("✔ Flask ready to run")
     else:
         app.run(host="0.0.0.0", port=port)
-        logger.info("Lancement de l'application Flask en local", {
-            "origin": "FLASK_START",
-            "port": port
-        })
+        logger.info(
+            "application flask démarrée",
+            {"origin": "FLASK_START", "code": "FLASK_START_LOCAL", "port": port},
+        )

--- a/backend/app/routes/pdf.py
+++ b/backend/app/routes/pdf.py
@@ -56,7 +56,15 @@ def proxy_pdf():
 
         t_1 = time.time()
 
-        log_backend.info(f"PDF downloaded in {t_1 - t_0} seconds", {"origin": "PDF_PROXY", "code": "PDF_DOWNLOADED", "url": url_result["url_notice_fr"]})
+        log_backend.info(
+            "pdf téléchargé",
+            {
+                "origin": "PDF_PROXY",
+                "code": "PDF_DOWNLOADED",
+                "url": url_result["url_notice_fr"],
+                "time": t_1 - t_0,
+            },
+        )
 
         return Response(
             r.content,
@@ -64,9 +72,12 @@ def proxy_pdf():
             headers={"Content-Disposition": "inline; filename=notice.pdf", "Content-Type": "application/pdf"}
         )
     except Exception as e:
-        log_backend.error(f"Error downloading PDF: {e}", {
-            "origin": "PDF_PROXY", 
-            "code": "PDF_DOWNLOAD_ERROR", 
-            "error": traceback.format_exc(),
-        })
+        log_backend.error(
+            "erreur téléchargement pdf",
+            {
+                "origin": "PDF_PROXY",
+                "code": "PDF_DOWNLOAD_ERROR",
+                "error": traceback.format_exc(),
+            },
+        )
         return f"Erreur lors du téléchargement : {e}", 500

--- a/backend/app/routes/personnal_calendar.py
+++ b/backend/app/routes/personnal_calendar.py
@@ -338,12 +338,15 @@ def download_pdf_calendar(calendar_id):
         t_1 = time.time()
 
         # Log facultatif
-        log_backend.info("PDF généré avec succès", {
-            "origin": "PDF_DOWNLOAD",
-            "uid": "unknown",
-            "code": "PDF_DOWNLOAD_SUCCESS",
-            "time": round(t_1 - t_0, 3),
-        })
+        log_backend.info(
+            "pdf généré",
+            {
+                "origin": "PDF_DOWNLOAD",
+                "code": "PDF_DOWNLOAD_SUCCESS",
+                "uid": "unknown",
+                "time": round(t_1 - t_0, 3),
+            },
+        )
 
         return Response(
             pdf_buffer.getvalue(),

--- a/backend/app/routes/status.py
+++ b/backend/app/routes/status.py
@@ -1,15 +1,24 @@
-from flask import request, jsonify
+from flask import request
 from . import api
 from app.utils.logging import log_backend as logger
+from app.utils.responses import success_response
 
 @api.route('/status', methods=['GET', 'HEAD'])
 def status():
     if request.method == 'HEAD':
-        logger.info("Requête HEAD reçue sur /api/status", {
-            "origin": "STATUS",
-        })
-        return '', 200
-    logger.info("Requête GET reçue sur /api/status", {
-        "origin": "STATUS",
-    })
-    return jsonify({"status": "ok"}), 200
+        logger.info(
+            "requête HEAD reçue",
+            {"origin": "STATUS", "code": "STATUS_CHECK_HEAD"},
+        )
+        return "", 200
+
+    logger.info(
+        "requête GET reçue",
+        {"origin": "STATUS", "code": "STATUS_CHECK_GET"},
+    )
+
+    return success_response(
+        message="statut ok",
+        code="STATUS_CHECK_SUCCESS",
+        origin="STATUS",
+    )

--- a/backend/app/services/calendar/core.py
+++ b/backend/app/services/calendar/core.py
@@ -30,10 +30,15 @@ def generate_calendar_schedule(calendar_id, start_date):
                     return [], [], None
 
     except Exception as e:
-        logger.error("erreur lors de la génération du calendrier", {
-            "origin": "CALENDAR_GENERATE_ERROR",
-            "error": str(e)
-        })
+        logger.error(
+            "erreur génération calendrier",
+            {
+                "origin": "CALENDAR_GENERATE",
+                "code": "CALENDAR_GENERATE_ERROR",
+                "calendar_id": calendar_id,
+                "error": str(e),
+            },
+        )
         return [], [], None
 
 
@@ -53,10 +58,14 @@ def is_medication_due(med, current_date):
 
         return delta_days % med["interval_days"] == 0
     except Exception as e:
-        logger.error(f"erreur lors de la vérification de la date de prise du médicament: {e}", {
-            "origin": "MEDICATION_DUE_ERROR",
-            "error": str(e)
-        })
+        logger.error(
+            "erreur vérification date de prise médicament",
+            {
+                "origin": "CALENDAR_GENERATE",
+                "code": "MEDICATION_DUE_ERROR",
+                "error": str(e),
+            },
+        )
         return False
 
 

--- a/backend/app/services/calendar/verification.py
+++ b/backend/app/services/calendar/verification.py
@@ -14,22 +14,30 @@ def verify_calendar_share(calendar_id : str, receiver_uid : str) -> bool:
                 cursor.execute("SELECT * FROM shared_calendars WHERE calendar_id = %s AND receiver_uid = %s", (calendar_id, receiver_uid,))
                 shared_calendar = cursor.fetchone()
                 if not shared_calendar:
-                    logger.warning("accès refusé", {
-                        "origin": "SHARED_VERIFY",
-                        "uid": receiver_uid,
-                        "calendar_id": calendar_id,
-                    })
+                    logger.warning(
+                        "accès calendrier refusé",
+                        {
+                            "origin": "SHARED_VERIFY",
+                            "code": "SHARED_VERIFY_DENIED",
+                            "uid": receiver_uid,
+                            "calendar_id": calendar_id,
+                        },
+                    )
                     return False
                 
                 return True
 
     except Exception as e:
-        logger.error("erreur lors de la vérification de l'accès au calendrier partagé", {
-            "origin": "SHARED_VERIFY_ERROR",
-            "uid": receiver_uid,
-            "calendar_id": calendar_id, 
-            "error": str(e)
-        })
+        logger.error(
+            "erreur vérification accès calendrier partagé",
+            {
+                "origin": "SHARED_VERIFY",
+                "code": "SHARED_VERIFY_ERROR",
+                "uid": receiver_uid,
+                "calendar_id": calendar_id,
+                "error": str(e),
+            },
+        )
         return False
 
 def verify_calendar(calendar_id : str, uid : str) -> bool:
@@ -44,12 +52,16 @@ def verify_calendar(calendar_id : str, uid : str) -> bool:
                 return True
 
     except Exception as e:
-        logger.error("erreur lors de la vérification de l'accès au calendrier", {
-            "origin": "CALENDAR_VERIFY_ERROR",
-            "uid": uid,
-            "calendar_id": calendar_id,
-            "error": str(e)
-        })
+        logger.error(
+            "erreur vérification accès calendrier",
+            {
+                "origin": "CALENDAR_VERIFY",
+                "code": "CALENDAR_VERIFY_ERROR",
+                "uid": uid,
+                "calendar_id": calendar_id,
+                "error": str(e),
+            },
+        )
         return False
 
 def verify_token(token : str) -> bool:
@@ -84,11 +96,15 @@ def verify_token(token : str) -> bool:
                 return calendar_id
 
     except Exception as e:
-        logger.error("erreur lors de la vérification du token", {
-            "origin": "TOKEN_VERIFY_ERROR",
-            "token": token,
-            "error": str(e)
-        })
+        logger.error(
+            "erreur vérification token",
+            {
+                "origin": "TOKEN_VERIFY",
+                "code": "TOKEN_VERIFY_ERROR",
+                "token": token,
+                "error": str(e),
+            },
+        )
         return False
 
 def verify_token_owner(token : str, uid : str) -> bool:
@@ -106,10 +122,14 @@ def verify_token_owner(token : str, uid : str) -> bool:
                 return True
 
     except Exception as e:
-        logger.error("erreur lors de la vérification de la propriété du token", {
-            "origin": "TOKEN_OWNER_VERIFY_ERROR",
-            "token": token,
-            "uid": uid,
-            "error": str(e)
-        })
+        logger.error(
+            "erreur vérification propriété token",
+            {
+                "origin": "TOKEN_OWNER_VERIFY",
+                "code": "TOKEN_OWNER_VERIFY_ERROR",
+                "token": token,
+                "uid": uid,
+                "error": str(e),
+            },
+        )
         return False

--- a/backend/app/services/medication/stock.py
+++ b/backend/app/services/medication/stock.py
@@ -49,7 +49,10 @@ def process_box_decrement(cursor, id_box, qty, start_date, days=7):
 
 # Vérifie les stocks faibles et envoie des notifications
 def check_low_stock_and_notify():
-    log_backend.info("🔍 Vérification des stocks faibles", {"origin": "STOCK", "code": "STOCK_CHECK_INIT"})
+    log_backend.info(
+        "vérification des stocks faibles",
+        {"origin": "STOCK", "code": "STOCK_CHECK_INIT"},
+    )
 
     try:
         with get_connection() as conn:
@@ -67,7 +70,10 @@ def check_low_stock_and_notify():
 
                 # Si aucun résultat, inutile d'aller plus loin
                 if not results:
-                    log_backend.info("✅ Aucun stock faible détecté", {"origin": "STOCK", "code": "STOCK_CHECK_EMPTY"})
+                    log_backend.info(
+                        "aucun stock faible détecté",
+                        {"origin": "STOCK", "code": "STOCK_CHECK_EMPTY"},
+                    )
                     return
 
                 # Extraire tous les calendar_id
@@ -112,7 +118,7 @@ def check_low_stock_and_notify():
             try:
                 notify_and_record(uid=uid, json_body=notifs, notif_type="low_stock")
                 log_backend.info(
-                    "✅ Notifications de stock faible envoyées",
+                    "notifications de stock faible envoyées",
                     {
                         "origin": "STOCK",
                         "code": "STOCK_CHECK_SUCCESS",
@@ -123,7 +129,7 @@ def check_low_stock_and_notify():
                 )
             except Exception as e:
                 log_backend.error(
-                    "Erreur envoi notifications stock faible",
+                    "erreur envoi notifications stock faible",
                     {
                         "origin": "STOCK",
                         "code": "STOCK_CHECK_ERROR",
@@ -133,11 +139,14 @@ def check_low_stock_and_notify():
                     },
                 )
 
-        log_backend.info("✅ Fin de la vérification des stocks", {"origin": "STOCK", "code": "STOCK_CHECK_DONE"})
+        log_backend.info(
+            "fin de la vérification des stocks",
+            {"origin": "STOCK", "code": "STOCK_CHECK_DONE"},
+        )
 
     except Exception as e:
         log_backend.error(
-            "Erreur lors de la vérification des stocks",
+            "erreur vérification des stocks",
             {"origin": "STOCK", "code": "STOCK_CHECK_FATAL", "error": str(e)},
         )
 
@@ -149,7 +158,7 @@ def check_low_stock_and_notify_for_calendar(calendar_id: int):
         calendar_id: ID du calendrier à vérifier.
     """
     log_backend.info(
-        "🔍 Vérification des stocks faibles pour le calendrier",
+        "vérification des stocks pour le calendrier",
         {"origin": "STOCK", "code": "STOCK_CHECK_CALENDAR_INIT", "calendar_id": calendar_id},
     )
 
@@ -180,7 +189,7 @@ def check_low_stock_and_notify_for_calendar(calendar_id: int):
 
         if not results:
             log_backend.info(
-                "Aucun stock faible trouvé pour le calendrier",
+                "aucun stock faible pour le calendrier",
                 {"origin": "STOCK", "code": "STOCK_CHECK_CALENDAR_EMPTY", "calendar_id": calendar_id},
             )
             return
@@ -211,7 +220,7 @@ def check_low_stock_and_notify_for_calendar(calendar_id: int):
             try:
                 notify_and_record(uid=uid, json_body=notifs, notif_type="low_stock")
                 log_backend.info(
-                    "✅ Notifications de stock faible envoyées pour le calendrier",
+                    "notifications de stock faible envoyées pour le calendrier",
                     {
                         "origin": "STOCK",
                         "code": "STOCK_CHECK_CALENDAR_SUCCESS",
@@ -222,24 +231,24 @@ def check_low_stock_and_notify_for_calendar(calendar_id: int):
                 )
             except Exception as e:
                 log_backend.error(
-                    "Erreur envoi notifications stock faible pour le calendrier",
+                    "erreur envoi notifications stock faible pour le calendrier",
                     {
                         "origin": "STOCK",
                         "code": "STOCK_CHECK_CALENDAR_ERROR",
                         "uid": uid,
                         "calendar_id": calendar_id,
                         "error": str(e),
-                    }
+                    },
                 )
     except Exception as e:
         log_backend.error(
-            "Erreur lors de la vérification des stocks pour le calendrier",
+            "erreur vérification des stocks pour le calendrier",
             {
-                "origin": "STOCK", 
-                "code": "STOCK_CHECK_CALENDAR_ERROR", 
-                "calendar_id": calendar_id, 
-                "error": str(e)
-            }
+                "origin": "STOCK",
+                "code": "STOCK_CHECK_CALENDAR_ERROR",
+                "calendar_id": calendar_id,
+                "error": str(e),
+            },
         )
 
 def check_if_stock_is_low(calendar_id: int) -> bool:

--- a/backend/app/services/notifications/core.py
+++ b/backend/app/services/notifications/core.py
@@ -30,7 +30,7 @@ def enrich_notification(notification: dict) -> dict:
         notification["sender_name"] = fetch_user_name(sender_uid)
     except Exception as e:
         log_backend.error(
-            "Erreur enrich_notification",
+            "erreur enrich_notification",
             {
                 "origin": "NOTIFICATIONS",
                 "code": "ENRICH_ERROR",
@@ -155,7 +155,7 @@ def save_notifications(uid: str, notif_type: str, notifications: list[dict]):
                 conn.commit()
     except Exception as e:
         log_backend.error(
-            "Erreur save_notifications",
+            "erreur save_notifications",
             {
                 "origin": "NOTIFICATIONS",
                 "code": "SAVE_ERROR",
@@ -194,7 +194,7 @@ def send_grouped_notifications(uid: str, notifications: list[dict], notif_type: 
             send_sms_notification(user, payload, notif_type)
     except Exception as e:
         log_backend.error(
-            "Erreur send_grouped_notifications",
+            "erreur send_grouped_notifications",
             {
                 "origin": "NOTIFICATIONS",
                 "code": "SEND_ERROR",
@@ -217,7 +217,7 @@ def send_push_notification(uid: str, payload: dict, notif_type: str) -> None:
         send_fcm_notification(tokens, title, body, payload)
     else:
         log_backend.warning(
-            f"Aucun token FCM trouvé pour l'utilisateur {uid}",
+            "token FCM introuvable",
             {"origin": "NOTIFICATIONS", "code": "NO_FCM_TOKEN", "uid": uid},
         )
 
@@ -225,7 +225,7 @@ def send_email_notification(user: dict, payload: dict, notif_type: str) -> None:
     email = user.get("email")
     if not email:
         log_backend.warning(
-            f"Aucun email trouvé pour l'utilisateur {user.get('id')}",
+            "email introuvable",
             {"origin": "NOTIFICATIONS", "code": "NO_EMAIL", "uid": user.get('id')},
         )
         return
@@ -238,7 +238,7 @@ def send_sms_notification(user: dict, payload: dict, notif_type: str) -> None:
     phone = user.get("phone")
     if not phone:
         log_backend.warning(
-            f"Aucun numéro de téléphone trouvé pour l'utilisateur {user.get('id')}",
+            "numéro de téléphone introuvable",
             {
                 "origin": "NOTIFICATIONS",
                 "code": "NO_PHONE_NUMBER",
@@ -284,7 +284,7 @@ def notify_and_record(uid: str, json_body, notif_type: str) -> None:
 
     except Exception as e:
         log_backend.error(
-            "Erreur notify_and_record",
+            "erreur notify_and_record",
             {
                 "origin": "NOTIFICATIONS",
                 "code": "NOTIFICATION_ERROR",

--- a/backend/app/services/notifications/messaging/send_email.py
+++ b/backend/app/services/notifications/messaging/send_email.py
@@ -31,6 +31,12 @@ def send_email(to, subject, html_content, plain=None):
             server.starttls()
             server.login(Config.NOTIFICATION_EMAIL_ADDRESS or "", Config.NOTIFICATION_EMAIL_PASSWORD or "")
             server.send_message(msg)
-        log_backend.info(f"Email sent to {to} with subject '{subject}'", {"origin": "EMAIL", "code": "EMAIL_SENT"})
+        log_backend.info(
+            "email envoyé",
+            {"origin": "EMAIL", "code": "EMAIL_SENT", "to": to, "subject": subject},
+        )
     except Exception as e:
-        log_backend.error(f"Error sending email: {e}", {"origin": "EMAIL", "code": "EMAIL_ERROR", "error": str(e)})
+        log_backend.error(
+            "erreur envoi email",
+            {"origin": "EMAIL", "code": "EMAIL_ERROR", "error": str(e)},
+        )

--- a/backend/app/services/notifications/messaging/send_sms.py
+++ b/backend/app/services/notifications/messaging/send_sms.py
@@ -11,8 +11,14 @@ def send_sms(to_number, message_body):
             messaging_service_sid=Config.TWILIO_MESSAGING_SERVICE_SID,
             body=message_body
         )
-        log_backend.info(f"SMS sent to {to_number} with message '{message_body}'", {"origin": "SMS", "code": "SMS_SENT"})
+        log_backend.info(
+            "sms envoyé",
+            {"origin": "SMS", "code": "SMS_SENT", "to": to_number},
+        )
     except Exception as e:
-        log_backend.error(f"Error sending SMS to {to_number}: {e}", {"origin": "SMS", "code": "SMS_ERROR"})
+        log_backend.error(
+            "erreur envoi SMS",
+            {"origin": "SMS", "code": "SMS_ERROR", "to": to_number, "error": str(e)},
+        )
         return {"success": False, "error": str(e)}
     return {"success": True, "sid": message.sid, "status": message.status}

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -18,15 +18,25 @@ def decode_token(token):
             options={"verify_aud": False}
         )
     except jwt.ExpiredSignatureError:
-        logger.warning("Token expiré", {"origin": "TOKEN_ERROR", "uid": "unknown"})
+        logger.warning(
+            "token expiré",
+            {"origin": "AUTH", "code": "TOKEN_EXPIRED", "uid": "unknown"},
+        )
     except jwt.InvalidTokenError:
-        logger.warning("Token invalide", {"origin": "TOKEN_ERROR", "uid": "unknown"})
+        logger.warning(
+            "token invalide",
+            {"origin": "AUTH", "code": "TOKEN_INVALID", "uid": "unknown"},
+        )
     except Exception as e:
-        logger.warning("Erreur lors de la vérification du token", {
-            "origin": "TOKEN_ERROR",
-            "uid": "unknown",
-            "error": str(e)
-        })
+        logger.warning(
+            "erreur vérification token",
+            {
+                "origin": "AUTH",
+                "code": "TOKEN_CHECK_ERROR",
+                "uid": "unknown",
+                "error": str(e),
+            },
+        )
     return None
 
 

--- a/backend/app/vertex/gemini.py
+++ b/backend/app/vertex/gemini.py
@@ -72,7 +72,10 @@ Rules:
         if response.candidates and response.candidates[0].content.parts:
             raw_output = response.candidates[0].content.parts[0].text
         else:
-            log_backend.warning("Gemini response structure unexpected", {"origin": "GEMINI_ANALYZE"})
+            log_backend.warning(
+                "structure de réponse gemini inattendue",
+                {"origin": "GEMINI_ANALYZE", "code": "GEMINI_BAD_STRUCTURE"},
+            )
             return {
                 "error": "Gemini returned unexpected response structure"
             }
@@ -83,21 +86,28 @@ Rules:
             data = json.loads(cleaned)
             return data
         except json.JSONDecodeError as json_error:
-            log_backend.warning("Gemini returned non-JSON output", {
-                "origin": "GEMINI_ANALYZE",
-                "raw_output": raw_output,
-                "error": str(json_error)
-            })
+            log_backend.warning(
+                "réponse gemini non JSON",
+                {
+                    "origin": "GEMINI_ANALYZE",
+                    "code": "GEMINI_NOT_JSON",
+                    "raw_output": raw_output,
+                    "error": str(json_error),
+                },
+            )
             return {
                 "error": "Gemini response was not valid JSON",
             }
 
     except Exception as e:
-        log_backend.exception("Error during Gemini analysis", {
-            "origin": "GEMINI_ANALYZE",
-            "code": "GEMINI_ERROR",
-            "error": str(e)
-        })
+        log_backend.exception(
+            "erreur analyse gemini",
+            {
+                "origin": "GEMINI_ANALYZE",
+                "code": "GEMINI_ERROR",
+                "error": str(e),
+            },
+        )
         return {
             "error": "An error occurred while analyzing the medical document"
         }


### PR DESCRIPTION
## Summary
- standardize `log_backend` usage across the backend
- return JSON success response for GET status
- harmonize calendar and auth logs

## Testing
- `python -m py_compile backend/app/routes/status.py`
- `python -m py_compile backend/app/services/calendar/core.py backend/app/services/calendar/verification.py backend/app/utils/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_6874e498be688328b1e6267bc49f23b7