### PR TITLE
Refactor shared list calendar card

### DIFF
--- a/frontend/src/pages/share/SharedList.jsx
+++ b/frontend/src/pages/share/SharedList.jsx
@@ -311,126 +311,129 @@ function SharedList({
         {Object.entries(groupedShared)
           .filter(([calendarId]) => calendarId === selectedCalendarId)
           .map(([calendarId, data]) => (
-            <div key={calendarId}>
-              <div className="card h-100 shadow border border-2">
-                <div className="card-body">
-                  {/* Nom du calendrier */}
-                  <h5 className="card-title mb-3 d-flex justify-content-between align-items-center">
-                    <span>{data.calendar_name}</span>
-                    <ActionSheet
-                      actions={[
-                        {
-                          label: (
-                            <>
-                              <i className="bi bi-eye me-2"></i> {t('open')}
-                            </>
-                          ),
-                          onClick: () => navigate(`/calendar/${calendarId}`),
-                        },
-                        {
-                          label: (
-                            <>
-                              <i className="bi bi-capsule me-2"></i> {t('medicines.label')}
-                            </>
-                          ),
-                          onClick: () => {
-                            navigate(`/calendar/${calendarId}/boxes`);
-                          },
-                        },
-                        { separator: true },
-                        {
-                          label: (
-                            <>
-                              <i className="bi bi-trash me-2"></i> {t('delete')}
-                            </>
-                          ),
-                          onClick: () => {
-                            setAlertType("confirm-danger");
-                            setAlertMessage(t("delete_calendar_confirm"));
-                            setAlertId(calendarId);
-                            setOnConfirmAction(() => async () => {
-                              const rep = await personalCalendars.deleteCalendar(calendarId);
-                              if (rep.success) {
-                                setAlertType("success");
-                                setAlertMessage("✅ " + rep.message);
-                                setTimeout(() => {
-                                  navigate("/calendars");
-                                }, 1000);
-                              } else {
-                                setAlertType("danger");
-                                setAlertMessage("❌ " + rep.error);
-                              }
-                            });
-                          },
-                          danger: true,
-                        },
-                      ]}
-                    />
-                  </h5>
-                  {alertId === calendarId && (
-                    <AlertSystem
-                      type={alertType}
-                      message={alertMessage}
-                      onClose={() => {
-                        setAlertMessage("");
-                        setOnConfirmAction(null);
-                        setAlertId(null);
-                      }}
-                      onConfirm={async () => {
-                        if (onConfirmAction) await onConfirmAction();
-                      }}
-                    />
-                  )}
+            <CalendarCard
+              key={calendarId}
+              calendarId={calendarId}
+              data={data}
+              alertId={alertId}
+              alertType={alertType}
+              alertMessage={alertMessage}
+              onConfirmAction={onConfirmAction}
+              setAlertType={setAlertType}
+              setAlertMessage={setAlertMessage}
+              setOnConfirmAction={setOnConfirmAction}
+              setAlertId={setAlertId}
+              handleCopyLink={handleCopyLink}
+              handleUpdateTokenExpiration={handleUpdateTokenExpiration}
+              handleUpdateTokenPermissions={handleUpdateTokenPermissions}
+              handleToggleToken={handleToggleToken}
+              deleteTokenConfirmAction={deleteTokenConfirmAction}
+              handleCreateToken={handleCreateToken}
+              today={today}
+              VITE_URL={VITE_URL}
+              selectedModifyCalendar={selectedModifyCalendar}
+              setSelectedModifyCalendar={setSelectedModifyCalendar}
+              tokenCalendars={tokenCalendars}
+              handleSendInvitation={handleSendInvitation}
+              deleteUserConfirmAction={deleteUserConfirmAction}
+              emailsToInvite={emailsToInvite}
+              setEmailsToInvite={setEmailsToInvite}
+              navigate={navigate}
+              personalCalendars={personalCalendars}
+            />
+          ))}
+      </div>
+    </div>
+  );
+}
 
-                  <hr className="my-3" />
+const calendarActions = (
+  calendarId,
+  navigate,
+  personalCalendars,
+  t,
+  setAlertType,
+  setAlertMessage,
+  setAlertId,
+  setOnConfirmAction,
+) => [
+  {
+    label: (
+      <>
+        <i className="bi bi-eye me-2"></i> {t("open")}
+      </>
+    ),
+    onClick: () => navigate(`/calendar/${calendarId}`),
+  },
+  {
+    label: (
+      <>
+        <i className="bi bi-capsule me-2"></i> {t("medicines.label")}
+      </>
+    ),
+    onClick: () => navigate(`/calendar/${calendarId}/boxes`),
+  },
+  { separator: true },
+  {
+    label: (
+      <>
+        <i className="bi bi-trash me-2"></i> {t("delete")}
+      </>
+    ),
+    onClick: () => {
+      setAlertType("confirm-danger");
+      setAlertMessage(t("delete_calendar_confirm"));
+      setAlertId(calendarId);
+      setOnConfirmAction(() => async () => {
+        const rep = await personalCalendars.deleteCalendar(calendarId);
+        if (rep.success) {
+          setAlertType("success");
+          setAlertMessage("✅ " + rep.message);
+          setTimeout(() => {
+            navigate("/calendars");
+          }, 1000);
+        } else {
+          setAlertType("danger");
+          setAlertMessage("❌ " + rep.error);
+        }
+      });
+    },
+    danger: true,
+  },
+];
 
-                  {/* Liens de partage */}
-                  <TokenList
-                    setAlertType={setAlertType}
-                    alertId={alertId}
-                    alertType={alertType}
-                    alertMessage={alertMessage}
-                    onConfirmAction={onConfirmAction}
-                    setAlertMessage={setAlertMessage}
-                    setOnConfirmAction={setOnConfirmAction}
-                    setAlertId={setAlertId}
-                    handleCopyLink={handleCopyLink}
-                    handleUpdateTokenExpiration={handleUpdateTokenExpiration}
-                    handleUpdateTokenPermissions={handleUpdateTokenPermissions}
-                    handleToggleToken={handleToggleToken}
-                    deleteTokenConfirmAction={deleteTokenConfirmAction}
-                    handleCreateToken={handleCreateToken}
-                    today={today}
-                    VITE_URL={VITE_URL}
-                    data={data}
-                    calendarId={calendarId}
-                    setSelectedModifyCalendar={setSelectedModifyCalendar}
-                    selectedModifyCalendar={selectedModifyCalendar}
-                    tokenCalendars={tokenCalendars}
-                  />
-
-                  <hr className="my-3" />
-
-                  {/* Utilisateurs partagés */}
-                  <UserList
-                    alertId={alertId}
-                    alertType={alertType}
-                    alertMessage={alertMessage}
-                    onConfirmAction={onConfirmAction}
-                    setAlertMessage={setAlertMessage}
-                    setOnConfirmAction={setOnConfirmAction}
-                    setAlertId={setAlertId}
-                    handleSendInvitation={handleSendInvitation}
-                    deleteUserConfirmAction={deleteUserConfirmAction}
-                    data={data}
-                    calendarId={calendarId}
-                    emailsToInvite={emailsToInvite}
-                    setEmailsToInvite={setEmailsToInvite}
-                  />
-                </div>
-              </div>
-            </div>
-        ))}
+function CalendarCard({
+  calendarId, data, alertId, alertType, alertMessage, onConfirmAction,
+  setAlertType, setAlertMessage, setOnConfirmAction, setAlertId,
+  handleCopyLink, handleUpdateTokenExpiration, handleUpdateTokenPermissions,
+  handleToggleToken, deleteTokenConfirmAction, handleCreateToken, today,
+  VITE_URL, selectedModifyCalendar, setSelectedModifyCalendar, tokenCalendars,
+  handleSendInvitation, deleteUserConfirmAction, emailsToInvite,
+  setEmailsToInvite, navigate, personalCalendars,
+}) {
+  const { t } = useTranslation();
+  const alertHandlers = { alertId, alertType, alertMessage, onConfirmAction, setAlertMessage, setOnConfirmAction, setAlertId };
+  const tokenProps = { ...alertHandlers, setAlertType, handleCopyLink, handleUpdateTokenExpiration, handleUpdateTokenPermissions, handleToggleToken, deleteTokenConfirmAction, handleCreateToken, today, VITE_URL, data, calendarId, selectedModifyCalendar, setSelectedModifyCalendar, tokenCalendars };
+  const userProps = { ...alertHandlers, handleSendInvitation, deleteUserConfirmAction, data, calendarId, emailsToInvite, setEmailsToInvite };
+  return (
+    <div className="card h-100 shadow border border-2">
+      <div className="card-body">
+        <h5 className="card-title mb-3 d-flex justify-content-between align-items-center">
+          <span>{data.calendar_name}</span>
+          <ActionSheet actions={calendarActions(calendarId, navigate, personalCalendars, t, setAlertType, setAlertMessage, setAlertId, setOnConfirmAction)} />
+        </h5>
+        {alertId === calendarId && (
+          <AlertSystem
+            type={alertType}
+            message={alertMessage}
+            onClose={() => { setAlertMessage(""); setOnConfirmAction(null); setAlertId(null); }}
+            onConfirm={async () => { if (onConfirmAction) await onConfirmAction(); }}
+          />
+        )}
+        <hr className="my-3" />
+        <TokenList {...tokenProps} />
+        <hr className="my-3" />
+        <UserList {...userProps} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- extract calendar item rendering into separate CalendarCard component to reduce complexity
- add reusable calendarActions helper for card action sheet

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68910a205f38832893e5f67726bd3d54