### PR TITLE
refactor: standardize supabase realtime hooks

### DIFF
--- a/frontend/src/hooks/realtime/useRealtimeBoxes.js
+++ b/frontend/src/hooks/realtime/useRealtimeBoxes.js
@@ -100,7 +100,7 @@ const useRealtimeBoxes = (
 
   const fetchData = useCallback(() => {
     if (!uid || !calendarId) return;
-    return fetchBoxes({ uid, calendarId, setBoxes, setLoadingBoxes, sourceType });
+    fetchBoxes({ uid, calendarId, setBoxes, setLoadingBoxes, sourceType });
   }, [uid, calendarId, setBoxes, setLoadingBoxes, sourceType]);
 
   const baseChannel =

--- a/frontend/src/hooks/realtime/useRealtimeBoxes.js
+++ b/frontend/src/hooks/realtime/useRealtimeBoxes.js
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useContext } from 'react';
+import { useEffect, useContext, useCallback } from 'react';
 import { supabase } from '../../services/supabase/supabaseClient';
 import { UserContext } from '../../contexts/UserContext';
 import { log } from '../../utils/logger';
 import { analyticsPromise } from '../../services/firebase/firebase';
 import { logEvent } from 'firebase/analytics';
+import { useSupabaseRealtime } from './useSupabaseRealtime';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -88,66 +89,42 @@ const useRealtimeBoxes = (
   setLoadingBoxes
 ) => {
   const { userInfo } = useContext(UserContext);
-  const channelRef = useRef(null);
 
   useEffect(() => {
     if (!userInfo || !calendarId) {
       setLoadingBoxes(undefined);
-      return;
     }
+  }, [userInfo, calendarId, setLoadingBoxes]);
 
-    const uid = userInfo.uid;
-    fetchBoxes({ uid, calendarId, setBoxes, setLoadingBoxes, sourceType });
+  const uid = userInfo?.uid;
 
-    const baseChannel =
-      sourceType === 'personal' ? 'personal-meds' : 'shared-meds';
-    const deleteChannel =
-      sourceType === 'personal' ? 'delete-personal-meds' : 'delete-shared-meds';
+  const fetchData = useCallback(() => {
+    if (!uid || !calendarId) return;
+    return fetchBoxes({ uid, calendarId, setBoxes, setLoadingBoxes, sourceType });
+  }, [uid, calendarId, setBoxes, setLoadingBoxes, sourceType]);
 
-    const channel = supabase
-      .channel(`${baseChannel}-${calendarId}`)
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'medicine_boxes',
-          filter: `calendar_id=eq.${calendarId}`,
-        },
-        () =>
-          fetchBoxes({ uid, calendarId, setBoxes, setLoadingBoxes, sourceType })
-      )
-      .subscribe();
+  const baseChannel =
+    sourceType === 'personal' ? 'personal-meds' : 'shared-meds';
+  const deleteChannel =
+    sourceType === 'personal' ? 'delete-personal-meds' : 'delete-shared-meds';
 
-    const deletion = supabase
-      .channel(`${deleteChannel}-${calendarId}`)
-      .on(
-        'postgres_changes',
-        {
-          event: 'DELETE',
-          schema: 'public',
-          table: 'medicine_boxes',
-        },
-        () =>
-          fetchBoxes({ uid, calendarId, setBoxes, setLoadingBoxes, sourceType })
-      )
-      .subscribe();
-
-    channelRef.current = { channel, deletion };
-
-    return () => {
-      try {
-        channel.unsubscribe();
-        deletion.unsubscribe();
-        channelRef.current = null;
-      } catch (err) {
-        log.error('Erreur lors de la désinscription des canaux Supabase', {
-          error: err,
-          origin: 'REALTIME_MEDICINE_BOXES_CLEANUP_ERROR',
-        });
-      }
-    };
-  }, [userInfo, calendarId, sourceType]);
+  useSupabaseRealtime({
+    enabled: !!uid && !!calendarId,
+    fetchData,
+    channels: [
+      {
+        channelName: `${baseChannel}-${calendarId}`,
+        table: 'medicine_boxes',
+        filter: `calendar_id=eq.${calendarId}`,
+      },
+      {
+        channelName: `${deleteChannel}-${calendarId}`,
+        event: 'DELETE',
+        table: 'medicine_boxes',
+      },
+    ],
+    deps: [uid, calendarId, sourceType],
+  });
 };
 
 export const useRealtimePersonalBoxes = (

--- a/frontend/src/hooks/realtime/useRealtimeCalendars.js
+++ b/frontend/src/hooks/realtime/useRealtimeCalendars.js
@@ -1,9 +1,10 @@
-import { useEffect, useContext, useRef } from 'react';
+import { useContext, useCallback } from 'react';
 import { supabase } from '../../services/supabase/supabaseClient';
 import { log } from '../../utils/logger';
 import { UserContext } from '../../contexts/UserContext';
 import { analyticsPromise } from '../../services/firebase/firebase';
 import { logEvent } from 'firebase/analytics';
+import { useSupabaseRealtime } from './useSupabaseRealtime';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -100,56 +101,31 @@ const fetchSharedCalendars = async (
 
 export const useRealtimeCalendars = (setCalendarsData, setLoadingStates) => {
   const { userInfo } = useContext(UserContext);
-  const channelRef = useRef(null);
+  const uid = userInfo?.uid;
 
-  useEffect(() => {
-    if (!userInfo || !setCalendarsData) return;
-
+  const fetchData = useCallback(() => {
+    if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, calendars: true }));
-    fetchCalendars(userInfo.uid, setCalendarsData, setLoadingStates);
+    return fetchCalendars(uid, setCalendarsData, setLoadingStates);
+  }, [uid, setCalendarsData, setLoadingStates]);
 
-    const channel = supabase
-      .channel('calendars-realtime')
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'calendars',
-          filter: `owner_uid=eq.${userInfo.uid}`,
-        },
-        () => fetchCalendars(userInfo.uid, setCalendarsData, setLoadingStates)
-      )
-      .subscribe();
-
-    const deleteChannel = supabase
-      .channel('calendars-delete-watch')
-      .on(
-        'postgres_changes',
-        {
-          event: 'DELETE',
-          schema: 'public',
-          table: 'calendars',
-        },
-        () => fetchCalendars(userInfo.uid, setCalendarsData, setLoadingStates)
-      )
-      .subscribe();
-
-    channelRef.current = { channel, deleteChannel };
-
-    return () => {
-      try {
-        channel.unsubscribe();
-        deleteChannel.unsubscribe();
-        channelRef.current = null;
-      } catch (err) {
-        log.error('Erreur lors de la désinscription des canaux Supabase', {
-          error: err,
-          origin: 'REALTIME_CALENDARS_CLEANUP_ERROR',
-        });
-      }
-    };
-  }, [userInfo, setCalendarsData, setLoadingStates]);
+  useSupabaseRealtime({
+    enabled: !!uid && !!setCalendarsData,
+    fetchData,
+    channels: [
+      {
+        channelName: 'calendars-realtime',
+        table: 'calendars',
+        filter: `owner_uid=eq.${uid}`,
+      },
+      {
+        channelName: 'calendars-delete-watch',
+        event: 'DELETE',
+        table: 'calendars',
+      },
+    ],
+    deps: [uid],
+  });
 };
 
 export const useRealtimeSharedCalendars = (
@@ -157,68 +133,29 @@ export const useRealtimeSharedCalendars = (
   setLoadingStates
 ) => {
   const { userInfo } = useContext(UserContext);
-  const channelRef = useRef(null);
+  const uid = userInfo?.uid;
 
-  useEffect(() => {
-    if (!userInfo || !setSharedCalendarsData) return;
-
+  const fetchData = useCallback(() => {
+    if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, sharedCalendars: true }));
-    fetchSharedCalendars(
-      userInfo.uid,
-      setSharedCalendarsData,
-      setLoadingStates
-    );
+    return fetchSharedCalendars(uid, setSharedCalendarsData, setLoadingStates);
+  }, [uid, setSharedCalendarsData, setLoadingStates]);
 
-    const channel = supabase
-      .channel('shared-calendars-realtime')
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'shared_calendars',
-          filter: `receiver_uid=eq.${userInfo.uid}`,
-        },
-        () =>
-          fetchSharedCalendars(
-            userInfo.uid,
-            setSharedCalendarsData,
-            setLoadingStates
-          )
-      )
-      .subscribe();
-
-    const deleteChannel = supabase
-      .channel('shared-calendars-delete-watch')
-      .on(
-        'postgres_changes',
-        {
-          event: 'DELETE',
-          schema: 'public',
-          table: 'shared_calendars',
-        },
-        () =>
-          fetchSharedCalendars(
-            userInfo.uid,
-            setSharedCalendarsData,
-            setLoadingStates
-          )
-      )
-      .subscribe();
-
-    channelRef.current = { channel, deleteChannel };
-
-    return () => {
-      try {
-        channel.unsubscribe();
-        deleteChannel.unsubscribe();
-        channelRef.current = null;
-      } catch (err) {
-        log.error('Erreur lors de la désinscription des canaux Supabase', {
-          error: err,
-          origin: 'REALTIME_SHARED_CALENDARS_CLEANUP_ERROR',
-        });
-      }
-    };
-  }, [userInfo, setSharedCalendarsData, setLoadingStates]);
+  useSupabaseRealtime({
+    enabled: !!uid && !!setSharedCalendarsData,
+    fetchData,
+    channels: [
+      {
+        channelName: 'shared-calendars-realtime',
+        table: 'shared_calendars',
+        filter: `receiver_uid=eq.${uid}`,
+      },
+      {
+        channelName: 'shared-calendars-delete-watch',
+        event: 'DELETE',
+        table: 'shared_calendars',
+      },
+    ],
+    deps: [uid],
+  });
 };

--- a/frontend/src/hooks/realtime/useRealtimeCalendars.js
+++ b/frontend/src/hooks/realtime/useRealtimeCalendars.js
@@ -106,7 +106,7 @@ export const useRealtimeCalendars = (setCalendarsData, setLoadingStates) => {
   const fetchData = useCallback(() => {
     if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, calendars: true }));
-    return fetchCalendars(uid, setCalendarsData, setLoadingStates);
+    fetchCalendars(uid, setCalendarsData, setLoadingStates);
   }, [uid, setCalendarsData, setLoadingStates]);
 
   useSupabaseRealtime({
@@ -138,7 +138,7 @@ export const useRealtimeSharedCalendars = (
   const fetchData = useCallback(() => {
     if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, sharedCalendars: true }));
-    return fetchSharedCalendars(uid, setSharedCalendarsData, setLoadingStates);
+    fetchSharedCalendars(uid, setSharedCalendarsData, setLoadingStates);
   }, [uid, setSharedCalendarsData, setLoadingStates]);
 
   useSupabaseRealtime({

--- a/frontend/src/hooks/realtime/useRealtimeMedicines.js
+++ b/frontend/src/hooks/realtime/useRealtimeMedicines.js
@@ -1,8 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { analyticsPromise } from '../../services/firebase/firebase';
 import { log } from '../../utils/logger';
 import { logEvent } from 'firebase/analytics';
 import { supabase } from '../../services/supabase/supabaseClient';
+import { useSupabaseRealtime } from './useSupabaseRealtime';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -47,7 +48,7 @@ export const useRealtimeTokenMedicines = (
   setMedicinesData,
   setLoadingMedicines
 ) => {
-  const channelRef = useRef(null);
+  const [calendarId, setCalendarId] = useState(null);
 
   useEffect(() => {
     if (!token) return;
@@ -58,29 +59,11 @@ export const useRealtimeTokenMedicines = (
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
 
-        const { calendar_id } = data;
-        if (!calendar_id) {
+        if (!data.calendar_id) {
           throw new Error('calendar_id manquant dans le token');
         }
 
-        await fetchTokenMedicines(token, setMedicinesData, setLoadingMedicines);
-
-        const realtimeChannel = supabase
-          .channel(`token-meds-${calendar_id}`)
-          .on(
-            'postgres_changes',
-            {
-              event: '*',
-              schema: 'public',
-              table: 'medicines',
-              filter: `calendar_id=eq.${calendar_id}`,
-            },
-            () =>
-              fetchTokenMedicines(token, setMedicinesData, setLoadingMedicines)
-          )
-          .subscribe();
-
-        channelRef.current = realtimeChannel;
+        setCalendarId(data.calendar_id);
       } catch (err) {
         setLoadingMedicines(false);
         log.error(err.message, err, {
@@ -91,17 +74,23 @@ export const useRealtimeTokenMedicines = (
     };
 
     initListener();
+  }, [token, setLoadingMedicines]);
 
-    return () => {
-      try {
-        channelRef.current?.unsubscribe();
-        channelRef.current = null;
-      } catch (err) {
-        log.error('Erreur lors du nettoyage du canal Supabase token', err, {
-          origin: 'REALTIME_TOKEN_CLEANUP_ERROR',
-          token,
-        });
-      }
-    };
-  }, [token]);
+  const fetchData = useCallback(() => {
+    if (!token) return;
+    return fetchTokenMedicines(token, setMedicinesData, setLoadingMedicines);
+  }, [token, setMedicinesData, setLoadingMedicines]);
+
+  useSupabaseRealtime({
+    enabled: !!calendarId && !!token,
+    fetchData,
+    channels: [
+      {
+        channelName: `token-meds-${calendarId}`,
+        table: 'medicines',
+        filter: `calendar_id=eq.${calendarId}`,
+      },
+    ],
+    deps: [token, calendarId],
+  });
 };

--- a/frontend/src/hooks/realtime/useRealtimeMedicines.js
+++ b/frontend/src/hooks/realtime/useRealtimeMedicines.js
@@ -78,7 +78,7 @@ export const useRealtimeTokenMedicines = (
 
   const fetchData = useCallback(() => {
     if (!token) return;
-    return fetchTokenMedicines(token, setMedicinesData, setLoadingMedicines);
+    fetchTokenMedicines(token, setMedicinesData, setLoadingMedicines);
   }, [token, setMedicinesData, setLoadingMedicines]);
 
   useSupabaseRealtime({

--- a/frontend/src/hooks/realtime/useRealtimeNotifications.js
+++ b/frontend/src/hooks/realtime/useRealtimeNotifications.js
@@ -1,9 +1,10 @@
-import { useContext, useEffect, useRef } from 'react';
+import { useContext, useCallback } from 'react';
 import { UserContext } from '../../contexts/UserContext';
 import { analyticsPromise } from '../../services/firebase/firebase';
 import { supabase } from '../../services/supabase/supabaseClient';
 import { log } from '../../utils/logger';
 import { logEvent } from 'firebase/analytics';
+import { useSupabaseRealtime } from './useSupabaseRealtime';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -62,42 +63,24 @@ export const useRealtimeNotifications = (
   setLoadingStates
 ) => {
   const { userInfo } = useContext(UserContext);
-  const channelRef = useRef(null);
+  const uid = userInfo?.uid;
 
-  useEffect(() => {
-    if (!userInfo || !setNotificationsData) return;
-
-    const uid = userInfo.uid;
+  const fetchData = useCallback(() => {
+    if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, notifications: true }));
-    fetchNotifications(uid, setNotificationsData, setLoadingStates);
+    return fetchNotifications(uid, setNotificationsData, setLoadingStates);
+  }, [uid, setNotificationsData, setLoadingStates]);
 
-    const channel = supabase
-      .channel(`notifications-${uid}`)
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'notifications',
-          filter: `user_id=eq.${uid}`,
-        },
-        () => {
-          fetchNotifications(uid, setNotificationsData, setLoadingStates);
-        }
-      )
-      .subscribe();
-
-    channelRef.current = channel;
-
-    return () => {
-      try {
-        channelRef.current?.unsubscribe();
-        channelRef.current = null;
-      } catch (err) {
-        log.error('Erreur lors de la désinscription du canal Supabase', err, {
-          origin: 'REALTIME_NOTIFICATIONS_UNSUBSCRIBE_ERROR',
-        });
-      }
-    };
-  }, [userInfo, setNotificationsData, setLoadingStates]);
+  useSupabaseRealtime({
+    enabled: !!uid && !!setNotificationsData,
+    fetchData,
+    channels: [
+      {
+        channelName: `notifications-${uid}`,
+        table: 'notifications',
+        filter: `user_id=eq.${uid}`,
+      },
+    ],
+    deps: [uid],
+  });
 };

--- a/frontend/src/hooks/realtime/useRealtimeNotifications.js
+++ b/frontend/src/hooks/realtime/useRealtimeNotifications.js
@@ -68,7 +68,7 @@ export const useRealtimeNotifications = (
   const fetchData = useCallback(() => {
     if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, notifications: true }));
-    return fetchNotifications(uid, setNotificationsData, setLoadingStates);
+    fetchNotifications(uid, setNotificationsData, setLoadingStates);
   }, [uid, setNotificationsData, setLoadingStates]);
 
   useSupabaseRealtime({

--- a/frontend/src/hooks/realtime/useRealtimeTokens.js
+++ b/frontend/src/hooks/realtime/useRealtimeTokens.js
@@ -1,105 +1,73 @@
-import { useContext, useEffect, useRef } from 'react';
+import { useContext, useCallback } from 'react';
 import { UserContext } from '../../contexts/UserContext';
 import { analyticsPromise } from '../../services/firebase/firebase';
 import { log } from '../../utils/logger';
 import { logEvent } from 'firebase/analytics';
 import { supabase } from '../../services/supabase/supabaseClient';
+import { useSupabaseRealtime } from './useSupabaseRealtime';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
 export const useRealtimeTokens = (setTokensList, setLoadingStates) => {
   const { userInfo } = useContext(UserContext);
-  const channelRef = useRef(null);
+  const uid = userInfo?.uid;
 
-  useEffect(() => {
-    if (!userInfo || !setTokensList) return;
+  const fetchTokens = useCallback(async () => {
+    if (!uid) return;
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) throw new Error('Session Supabase non trouvée');
 
-    const uid = userInfo.uid;
+      const res = await fetch(`${API_URL}/api/tokens`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
 
-    const fetchTokens = async () => {
-      try {
-        const {
-          data: { session },
-        } = await supabase.auth.getSession();
-        if (!session) throw new Error('Session Supabase non trouvée');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error);
 
-        const res = await fetch(`${API_URL}/api/tokens`, {
-          headers: { Authorization: `Bearer ${session.access_token}` },
-        });
+      setTokensList(data.tokens);
+      setLoadingStates((prev) => ({ ...prev, tokens: false }));
 
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.error);
+      analyticsPromise.then((analytics) => {
+        if (analytics) {
+          logEvent(analytics, 'fetch_tokens', {
+            uid,
+            count: data.tokens?.length,
+          });
+        }
+      });
 
-        setTokensList(data.tokens);
-        setLoadingStates((prev) => ({ ...prev, tokens: false }));
+      log.info(data.message, {
+        origin: 'TOKENS_FETCH_SUCCESS',
+        uid,
+        count: data.tokens.length,
+      });
+    } catch (err) {
+      setLoadingStates((prev) => ({ ...prev, tokens: false }));
+      log.error(err.message || 'Échec de récupération des tokens', err, {
+        origin: 'TOKENS_FETCH_ERROR',
+        uid,
+      });
+    }
+  }, [uid, setTokensList, setLoadingStates]);
 
-        analyticsPromise.then((analytics) => {
-          if (analytics) {
-            logEvent(analytics, 'fetch_tokens', {
-              uid,
-              count: data.tokens?.length,
-            });
-          }
-        });
-
-        log.info(data.message, {
-          origin: 'TOKENS_FETCH_SUCCESS',
-          uid,
-          count: data.tokens.length,
-        });
-      } catch (err) {
-        setLoadingStates((prev) => ({ ...prev, tokens: false }));
-        log.error(err.message || 'Échec de récupération des tokens', err, {
-          origin: 'TOKENS_FETCH_ERROR',
-          uid,
-        });
-      }
-    };
-
-    // Fetch initial
-    fetchTokens();
-
-    // Supabase Realtime
-    const tokenChannel = supabase
-      .channel(`tokens-${uid}`)
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'shared_tokens',
-          filter: `owner_uid=eq.${uid}`,
-        },
-        () => fetchTokens()
-      )
-      .subscribe();
-
-    const deleteChannel = supabase
-      .channel(`delete-tokens-${uid}`)
-      .on(
-        'postgres_changes',
-        {
-          event: 'DELETE',
-          schema: 'public',
-          table: 'shared_tokens',
-        },
-        () => fetchTokens()
-      )
-      .subscribe();
-
-    channelRef.current = [tokenChannel, deleteChannel];
-
-    return () => {
-      try {
-        tokenChannel.unsubscribe();
-        deleteChannel.unsubscribe();
-        channelRef.current = null;
-      } catch (err) {
-        log.error('Erreur lors de la désinscription des canaux token', err, {
-          origin: 'REALTIME_TOKENS_UNSUBSCRIBE_ERROR',
-          uid,
-        });
-      }
-    };
-  }, [userInfo, setTokensList, setLoadingStates]);
+  useSupabaseRealtime({
+    enabled: !!uid && !!setTokensList,
+    fetchData: fetchTokens,
+    channels: [
+      {
+        channelName: `tokens-${uid}`,
+        table: 'shared_tokens',
+        filter: `owner_uid=eq.${uid}`,
+      },
+      {
+        channelName: `delete-tokens-${uid}`,
+        event: 'DELETE',
+        table: 'shared_tokens',
+      },
+    ],
+    deps: [uid],
+  });
 };

--- a/frontend/src/hooks/realtime/useSupabaseRealtime.js
+++ b/frontend/src/hooks/realtime/useSupabaseRealtime.js
@@ -44,6 +44,5 @@ export const useSupabaseRealtime = ({
       });
       channelRef.current = [];
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, ...deps]);
 };

--- a/frontend/src/hooks/realtime/useSupabaseRealtime.js
+++ b/frontend/src/hooks/realtime/useSupabaseRealtime.js
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { supabase } from '../../services/supabase/supabaseClient';
+import { log } from '../../utils/logger';
+
+/**
+ * Standardized supabase realtime subscription hook.
+ * @param {Object} options
+ * @param {boolean} options.enabled - If false, no subscription is created.
+ * @param {Function} options.fetchData - Function called initially and on every event.
+ * @param {Array} options.channels - Array of channel configs
+ *   ({ channelName, event='*', schema='public', table, filter }).
+ * @param {Array} [options.deps] - Additional dependencies for the effect.
+ */
+export const useSupabaseRealtime = ({
+  enabled,
+  fetchData,
+  channels,
+  deps = [],
+}) => {
+  const channelRef = useRef([]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    fetchData();
+
+    channelRef.current = channels.map(
+      ({ channelName, event = '*', schema = 'public', table, filter }) =>
+        supabase
+          .channel(channelName)
+          .on('postgres_changes', { event, schema, table, filter }, fetchData)
+          .subscribe()
+    );
+
+    return () => {
+      channelRef.current.forEach((ch) => {
+        try {
+          ch.unsubscribe();
+        } catch (err) {
+          log.error('Erreur lors de la désinscription des canaux Supabase', err, {
+            origin: 'REALTIME_CLEANUP_ERROR',
+          });
+        }
+      });
+      channelRef.current = [];
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, ...deps]);
+};


### PR DESCRIPTION
## Summary
- add `useSupabaseRealtime` helper to manage subscriptions
- refactor existing realtime hooks to use the helper

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892091a0e748328b1c06db83e60674f