### PR TITLE
refactor: clean return behavior in realtime hooks

### DIFF
--- a/frontend/src/hooks/realtime/useRealtimeBoxes.js
+++ b/frontend/src/hooks/realtime/useRealtimeBoxes.js
@@ -100,7 +100,7 @@ const useRealtimeBoxes = (
 
   const fetchData = useCallback(() => {
     if (!uid || !calendarId) return;
-    return fetchBoxes({ uid, calendarId, setBoxes, setLoadingBoxes, sourceType });
+    fetchBoxes({ uid, calendarId, setBoxes, setLoadingBoxes, sourceType });
   }, [uid, calendarId, setBoxes, setLoadingBoxes, sourceType]);
 
   const baseChannel =

--- a/frontend/src/hooks/realtime/useRealtimeCalendars.js
+++ b/frontend/src/hooks/realtime/useRealtimeCalendars.js
@@ -106,7 +106,7 @@ export const useRealtimeCalendars = (setCalendarsData, setLoadingStates) => {
   const fetchData = useCallback(() => {
     if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, calendars: true }));
-    return fetchCalendars(uid, setCalendarsData, setLoadingStates);
+    fetchCalendars(uid, setCalendarsData, setLoadingStates);
   }, [uid, setCalendarsData, setLoadingStates]);
 
   useSupabaseRealtime({
@@ -138,7 +138,7 @@ export const useRealtimeSharedCalendars = (
   const fetchData = useCallback(() => {
     if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, sharedCalendars: true }));
-    return fetchSharedCalendars(uid, setSharedCalendarsData, setLoadingStates);
+    fetchSharedCalendars(uid, setSharedCalendarsData, setLoadingStates);
   }, [uid, setSharedCalendarsData, setLoadingStates]);
 
   useSupabaseRealtime({

--- a/frontend/src/hooks/realtime/useRealtimeMedicines.js
+++ b/frontend/src/hooks/realtime/useRealtimeMedicines.js
@@ -78,7 +78,7 @@ export const useRealtimeTokenMedicines = (
 
   const fetchData = useCallback(() => {
     if (!token) return;
-    return fetchTokenMedicines(token, setMedicinesData, setLoadingMedicines);
+    fetchTokenMedicines(token, setMedicinesData, setLoadingMedicines);
   }, [token, setMedicinesData, setLoadingMedicines]);
 
   useSupabaseRealtime({

--- a/frontend/src/hooks/realtime/useRealtimeNotifications.js
+++ b/frontend/src/hooks/realtime/useRealtimeNotifications.js
@@ -68,7 +68,7 @@ export const useRealtimeNotifications = (
   const fetchData = useCallback(() => {
     if (!uid) return;
     setLoadingStates((prev) => ({ ...prev, notifications: true }));
-    return fetchNotifications(uid, setNotificationsData, setLoadingStates);
+    fetchNotifications(uid, setNotificationsData, setLoadingStates);
   }, [uid, setNotificationsData, setLoadingStates]);
 
   useSupabaseRealtime({

--- a/frontend/src/hooks/realtime/useSupabaseRealtime.js
+++ b/frontend/src/hooks/realtime/useSupabaseRealtime.js
@@ -44,6 +44,5 @@ export const useSupabaseRealtime = ({
       });
       channelRef.current = [];
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, ...deps]);
 };


### PR DESCRIPTION
## Summary
- avoid mixing return statements in realtime hooks
- drop obsolete ESLint disable comment

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_6892542edd108328bfa6ba71f740d73d