### PR TITLE
feat(auth): handle redirect after login

### DIFF
--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -34,15 +34,17 @@ function Auth() {
 
   const location = useLocation();
   const navigate = useNavigate();
-  const [redirect, setRedirect] = useState(() =>
-    getValidRedirect(new URLSearchParams(window.location.search).get('redirect'))
-  );
+  const [redirect, setRedirect] = useState();
   useEffect(() => {
     setActiveTab(location.pathname === '/register' ? 'register' : 'login');
     setRedirect(
-      getValidRedirect(new URLSearchParams(location.search).get('redirect'))
+      new URLSearchParams(location.search).get('redirect')
     );
   }, [location.pathname, location.search]);
+
+  useEffect(() => {
+    console.log(redirect);
+  }, [redirect]);
 
   const switchTab = (tab) => {
     if (tab !== activeTab) setActiveTab(tab);

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -34,10 +34,15 @@ function Auth() {
 
   const location = useLocation();
   const navigate = useNavigate();
-  const redirect = getValidRedirect(new URLSearchParams(location.search).get('redirect'));
+  const [redirect, setRedirect] = useState(() =>
+    getValidRedirect(new URLSearchParams(window.location.search).get('redirect'))
+  );
   useEffect(() => {
     setActiveTab(location.pathname === '/register' ? 'register' : 'login');
-  }, [location.pathname]);
+    setRedirect(
+      getValidRedirect(new URLSearchParams(location.search).get('redirect'))
+    );
+  }, [location.pathname, location.search]);
 
   const switchTab = (tab) => {
     if (tab !== activeTab) setActiveTab(tab);
@@ -180,7 +185,7 @@ function Auth() {
               e.preventDefault();
               try {
                 if (activeTab === 'login') {
-                  const error = await loginWithEmail(email, password);
+                  const error = await loginWithEmail(email, password, redirect);
                   if (error) {
                     setAlertMessage('❌ ' + t(`supabase-error.${error.code || 'unexpected_error'}`));
                     setAlertType('danger');

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -38,7 +38,7 @@ function Auth() {
   useEffect(() => {
     setActiveTab(location.pathname === '/register' ? 'register' : 'login');
     setRedirect(
-      new URLSearchParams(location.search).get('redirect')
+      getValidRedirect(new URLSearchParams(location.search).get('redirect'))
     );
   }, [location.pathname, location.search]);
 

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -15,6 +15,7 @@ import { log } from '../../utils/logger';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { UserContext } from '../../contexts/UserContext';
+import { getValidRedirect } from '../../utils/redirect';
 
 function Auth() {
   const { userInfo } = useContext(UserContext);
@@ -33,6 +34,7 @@ function Auth() {
 
   const location = useLocation();
   const navigate = useNavigate();
+  const redirect = getValidRedirect(new URLSearchParams(location.search).get('redirect'));
   useEffect(() => {
     setActiveTab(location.pathname === '/register' ? 'register' : 'login');
   }, [location.pathname]);
@@ -86,7 +88,7 @@ function Auth() {
                 <div className="px-2">
                   <button
                     className="btn btn-outline-danger rounded-pill py-1 d-flex align-items-center justify-content-center gap-2"
-                    onClick={GoogleHandleLogin}
+                    onClick={() => GoogleHandleLogin(redirect)}
                     aria-label={t('auth.with_google')}
                     title={t('auth.with_google')}
                   >
@@ -99,7 +101,7 @@ function Auth() {
                 <div className="px-2">
                   <button
                     className="btn btn-outline-secondary rounded-pill py-1 d-flex align-items-center justify-content-center gap-2"
-                    onClick={GithubHandleLogin}
+                    onClick={() => GithubHandleLogin(redirect)}
                     aria-label={t('auth.with_github')}
                     title={t('auth.with_github')}
                   >
@@ -112,7 +114,7 @@ function Auth() {
                 <div className="px-2">
                   <button
                     className="btn btn-outline-primary rounded-pill py-1 d-flex align-items-center justify-content-center gap-2"
-                    onClick={DiscordHandleLogin}
+                    onClick={() => DiscordHandleLogin(redirect)}
                     aria-label={t('auth.with_discord')}
                     title={t('auth.with_discord')}
                   >
@@ -125,7 +127,7 @@ function Auth() {
                 <div className="px-2">
                   <button
                     className="btn btn-outline-info rounded-pill py-1 d-flex align-items-center justify-content-center gap-2"
-                    onClick={TwitterHandleLogin}
+                    onClick={() => TwitterHandleLogin(redirect)}
                     aria-label={t('auth.with_twitter')}
                     title={t('auth.with_twitter')}
                   >
@@ -138,7 +140,7 @@ function Auth() {
                 <div className="px-2">
                   <button
                     className="btn btn-outline-primary rounded-pill py-1 d-flex align-items-center justify-content-center gap-2"
-                    onClick={FacebookHandleLogin}
+                    onClick={() => FacebookHandleLogin(redirect)}
                     aria-label={t('auth.with_facebook')}
                     title={t('auth.with_facebook')}
                   >
@@ -152,7 +154,7 @@ function Auth() {
                 <div className="px-2">
                   <button
                     className="btn btn-outline-dark rounded-pill py-1 d-flex align-items-center justify-content-center gap-2"
-                    onClick={MicrosoftHandleLogin}
+                    onClick={() => MicrosoftHandleLogin(redirect)}
                     aria-label={t('auth.with_microsoft')}
                     title={t('auth.with_microsoft')}
                   >
@@ -188,9 +190,12 @@ function Auth() {
                       origin: 'Auth.jsx',
                       user: userInfo.uid,
                     });
+                    if (redirect) {
+                      navigate(redirect, { replace: true });
+                    }
                   }
                 } else {
-                  const error = await registerWithEmail(email, password, name);
+                  const error = await registerWithEmail(email, password, name, redirect);
                   if (error) {
                     setAlertMessage('❌ ' + t(`supabase-error.${error.code || 'unexpected_error'}`));
                     setAlertType('danger');

--- a/frontend/src/pages/auth/AuthCallback.jsx
+++ b/frontend/src/pages/auth/AuthCallback.jsx
@@ -17,16 +17,17 @@ const AuthCallback = () => {
   const redirectRef = useRef(null);
   const typeRef = useRef(null);
 
-  const redirectMap = {
-    recovery: '/reset-password-confirm',
-    invite: '/reset-password-confirm',
-    email_change: '/settings/account',
-    reauthentication: '/settings/security',
-    magiclink: '/calendars',
-    signup: '/calendars',
-  };
+  const redirectMap = new Map([
+    ['recovery', '/reset-password-confirm'],
+    ['invite', '/reset-password-confirm'],
+    ['email_change', '/settings/account'],
+    ['reauthentication', '/settings/security'],
+    ['magiclink', '/calendars'],
+    ['signup', '/calendars'],
+  ]);
 
-  const getRedirectPath = (type) => redirectMap[type] || '/calendars';
+  const getRedirectPath = (rawType) =>
+    redirectMap.get(String(rawType)) || '/calendars';
 
 
   // 1) Vérifie la session et lance le reloadUser

--- a/frontend/src/pages/auth/AuthCallback.jsx
+++ b/frontend/src/pages/auth/AuthCallback.jsx
@@ -1,8 +1,8 @@
 // src/pages/AuthCallback.jsx
-import { useEffect } from 'react';
+import { useEffect, useContext, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../../services/supabase/supabaseClient';
-import { getGlobalReloadUser } from '../../contexts/UserContext';
+import { getGlobalReloadUser, UserContext } from '../../contexts/UserContext';
 import { log } from '../../utils/logger';
 import { useTranslation } from 'react-i18next';
 import { getValidRedirect } from '../../utils/redirect';
@@ -11,13 +11,19 @@ const AuthCallback = () => {
   const navigate = useNavigate();
   const reloadUser = getGlobalReloadUser();
   const { t } = useTranslation();
+  const { userInfo } = useContext(UserContext);
 
+  // Pour stocker redirect et type entre les deux effets
+  const redirectRef = useRef(null);
+  const typeRef = useRef(null);
+
+  // 1) Vérifie la session et lance le reloadUser
   useEffect(() => {
     const handleRedirect = async () => {
       const search = new URLSearchParams(window.location.search);
       const hash = new URLSearchParams(window.location.hash.substring(1));
-      const redirect = getValidRedirect(search.get('redirect'));
-      const type = hash.get('type');
+      redirectRef.current = getValidRedirect(search.get('redirect'));
+      typeRef.current = hash.get('type');
 
       const {
         data: { session },
@@ -38,31 +44,40 @@ const AuthCallback = () => {
       log.info(t('auth_callback.success'), {
         origin: 'CALLBACK_SUCCESS',
         uid: user.id,
-        type,
-        redirect,
+        type: typeRef.current,
+        redirect: redirectRef.current,
       });
-
-      if (redirect) {
-        return navigate(redirect, { replace: true });
-      }
-
-      switch (type) {
-        case 'recovery':
-        case 'invite':
-          return navigate('/reset-password-confirm', { replace: true });
-        case 'email_change':
-          return navigate('/settings/account', { replace: true });
-        case 'reauthentication':
-          return navigate('/settings/security', { replace: true });
-        case 'magiclink':
-        case 'signup':
-        default:
-          return navigate('/', { replace: true });
-      }
     };
 
     handleRedirect();
   }, [navigate, reloadUser, t]);
+
+  // 2) Redirige quand userInfo est dispo
+  useEffect(() => {
+    if (!userInfo) return;
+
+    const redirect = redirectRef.current;
+    const type = typeRef.current;
+
+    if (redirect) {
+      navigate(redirect, { replace: true });
+      return;
+    }
+
+    switch (type) {
+      case 'recovery':
+      case 'invite':
+        navigate('/reset-password-confirm', { replace: true }); break;
+      case 'email_change':
+        navigate('/settings/account', { replace: true }); break;
+      case 'reauthentication':
+        navigate('/settings/security', { replace: true }); break;
+      case 'magiclink':
+      case 'signup':
+      default:
+        navigate('/calendars', { replace: true }); break;
+    }
+  }, [userInfo, navigate]);
 
   return <p>{t('auth_callback.loading')}</p>;
 };

--- a/frontend/src/pages/auth/AuthCallback.jsx
+++ b/frontend/src/pages/auth/AuthCallback.jsx
@@ -5,6 +5,7 @@ import { supabase } from '../../services/supabase/supabaseClient';
 import { getGlobalReloadUser } from '../../contexts/UserContext';
 import { log } from '../../utils/logger';
 import { useTranslation } from 'react-i18next';
+import { getValidRedirect } from '../../utils/redirect';
 
 const AuthCallback = () => {
   const navigate = useNavigate();
@@ -13,7 +14,9 @@ const AuthCallback = () => {
 
   useEffect(() => {
     const handleRedirect = async () => {
+      const search = new URLSearchParams(window.location.search);
       const hash = new URLSearchParams(window.location.hash.substring(1));
+      const redirect = getValidRedirect(search.get('redirect'));
       const type = hash.get('type');
 
       const {
@@ -26,7 +29,7 @@ const AuthCallback = () => {
           origin: 'CALLBACK_ERROR',
           uid: null,
         });
-        return navigate('/login');
+        return navigate('/login', { replace: true });
       }
 
       const user = session.user;
@@ -36,25 +39,30 @@ const AuthCallback = () => {
         origin: 'CALLBACK_SUCCESS',
         uid: user.id,
         type,
+        redirect,
       });
+
+      if (redirect) {
+        return navigate(redirect, { replace: true });
+      }
 
       switch (type) {
         case 'recovery':
         case 'invite':
-          return navigate('/reset-password-confirm');
+          return navigate('/reset-password-confirm', { replace: true });
         case 'email_change':
-          return navigate('/settings/account');
+          return navigate('/settings/account', { replace: true });
         case 'reauthentication':
-          return navigate('/settings/security');
+          return navigate('/settings/security', { replace: true });
         case 'magiclink':
         case 'signup':
         default:
-          return navigate('/');
+          return navigate('/', { replace: true });
       }
     };
 
     handleRedirect();
-  }, [navigate, reloadUser]);
+  }, [navigate, reloadUser, t]);
 
   return <p>{t('auth_callback.loading')}</p>;
 };

--- a/frontend/src/pages/auth/AuthCallback.jsx
+++ b/frontend/src/pages/auth/AuthCallback.jsx
@@ -17,6 +17,18 @@ const AuthCallback = () => {
   const redirectRef = useRef(null);
   const typeRef = useRef(null);
 
+  const redirectMap = {
+    recovery: '/reset-password-confirm',
+    invite: '/reset-password-confirm',
+    email_change: '/settings/account',
+    reauthentication: '/settings/security',
+    magiclink: '/calendars',
+    signup: '/calendars',
+  };
+
+  const getRedirectPath = (type) => redirectMap[type] || '/calendars';
+
+
   // 1) Vérifie la session et lance le reloadUser
   useEffect(() => {
     const handleRedirect = async () => {
@@ -64,19 +76,7 @@ const AuthCallback = () => {
       return;
     }
 
-    switch (type) {
-      case 'recovery':
-      case 'invite':
-        navigate('/reset-password-confirm', { replace: true }); break;
-      case 'email_change':
-        navigate('/settings/account', { replace: true }); break;
-      case 'reauthentication':
-        navigate('/settings/security', { replace: true }); break;
-      case 'magiclink':
-      case 'signup':
-      default:
-        navigate('/calendars', { replace: true }); break;
-    }
+    navigate(getRedirectPath(type), { replace: true });
   }, [userInfo, navigate]);
 
   return <p>{t('auth_callback.loading')}</p>;

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 
 import { UserContext } from '../contexts/UserContext';
 
@@ -32,18 +32,26 @@ import TermsPage from '../pages/general/TermsPage';
 import AuthCallback from '../pages/auth/AuthCallback';
 import CalendarSettingsPage from '../pages/calendar/CalendarSettingsPage';
 
+function buildFullPath(loc) {
+  const path = loc.pathname || '/';
+  const qs = loc.search || '';
+  const hash = loc.hash || '';
+  return `${path}${qs}${hash}`;
+}
+
 function PrivateRoute({ element }) {
   const { userInfo } = useContext(UserContext);
+  const location = useLocation();
 
   if (!userInfo) {
-    return <Navigate to="/home" />;
+    const full = buildFullPath(location);
+    return (
+      <Navigate
+        to={`/login?redirect=${encodeURIComponent(full)}`}
+        replace
+      />
+    );
   }
-  /*}
-  if (!userInfo.emailVerified) {
-    if (userInfo.provider === 'email') {
-      return <Navigate to="/verify-email" />;
-    }
-  }*/
   return element;
 }
 

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -7,10 +7,14 @@ import { getGlobalReloadUser } from '../../contexts/UserContext';
 // URL de l'API
 const API_URL = import.meta.env.VITE_API_URL;
 
-const buildCallbackUrl = (redirect) =>
-  window.location.origin +
-  '/auth/callback' +
-  (redirect ? `?redirect=${encodeURIComponent(redirect)}` : '');
+function buildCallbackUrl(redirect) {
+  console.log('Building callback URL with redirect:', redirect);
+  return (
+    window.location.origin +
+    '/auth/callback' +
+    (redirect ? `?redirect=${encodeURIComponent(redirect)}` : '')
+  );
+}
 
 export async function updateUserInfo({ display_name, email, photo_url, email_enabled, push_enabled, uid }) {
   
@@ -45,6 +49,7 @@ export async function updateUserInfo({ display_name, email, photo_url, email_ena
  */
 export const GoogleHandleLogin = async (redirect) => {
   try {
+    console.log(redirect)
     await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -216,13 +216,13 @@ export const registerWithEmail = async (email, password, name, redirect) => {
 /**
  * Connexion avec email et mot de passe
  */
-export const loginWithEmail = async (email, password) => {
+export const loginWithEmail = async (email, password, redirect) => {
   try {
     const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(redirect),
       },
     });
     if (error) {

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -7,6 +7,11 @@ import { getGlobalReloadUser } from '../../contexts/UserContext';
 // URL de l'API
 const API_URL = import.meta.env.VITE_API_URL;
 
+const buildCallbackUrl = (redirect) =>
+  window.location.origin +
+  '/auth/callback' +
+  (redirect ? `?redirect=${encodeURIComponent(redirect)}` : '');
+
 export async function updateUserInfo({ display_name, email, photo_url, email_enabled, push_enabled, uid }) {
   
   const body = {
@@ -38,12 +43,12 @@ export async function updateUserInfo({ display_name, email, photo_url, email_ena
 /**
  * Connexion avec Google
  */
-export const GoogleHandleLogin = async () => {
+export const GoogleHandleLogin = async (redirect) => {
   try {
-    await supabase.auth.signInWithOAuth({ 
+    await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(redirect),
         queryParams: {
           prompt: 'select_account',
           access_type: 'offline',
@@ -62,12 +67,12 @@ export const GoogleHandleLogin = async () => {
 /**
  * Connexion avec Github
  */
-export const GithubHandleLogin = async () => {
+export const GithubHandleLogin = async (redirect) => {
   try {
     await supabase.auth.signInWithOAuth({
       provider: 'github',
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(redirect),
         queryParams: {
           prompt: 'select_account',
           access_type: 'offline',
@@ -86,12 +91,12 @@ export const GithubHandleLogin = async () => {
 /**
  * Connexion avec Twitter
  */
-export const TwitterHandleLogin = async () => {
+export const TwitterHandleLogin = async (redirect) => {
   try {
     await supabase.auth.signInWithOAuth({
       provider: 'twitter',
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(redirect),
         queryParams: {
           prompt: 'select_account',
           access_type: 'offline',
@@ -110,12 +115,12 @@ export const TwitterHandleLogin = async () => {
 /**
  * Connexion avec Facebook
  */
-export const FacebookHandleLogin = async () => {
+export const FacebookHandleLogin = async (redirect) => {
   try {
     await supabase.auth.signInWithOAuth({
       provider: 'facebook',
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(redirect),
         queryParams: {
           prompt: 'select_account',
           access_type: 'offline',
@@ -134,12 +139,12 @@ export const FacebookHandleLogin = async () => {
 /**
  * Connexion avec Discord
  */
-export const DiscordHandleLogin = async () => {
+export const DiscordHandleLogin = async (redirect) => {
   try {
     await supabase.auth.signInWithOAuth({
       provider: 'discord',
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(redirect),
         queryParams: {
           prompt: 'select_account',
           access_type: 'offline',
@@ -158,12 +163,12 @@ export const DiscordHandleLogin = async () => {
 /**
  * Connexion avec Microsoft
  */
-export const MicrosoftHandleLogin = async () => {
+export const MicrosoftHandleLogin = async (redirect) => {
   try {
     await supabase.auth.signInWithOAuth({
       provider: 'azure',
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(redirect),
         queryParams: {
           prompt: 'select_account',
           access_type: 'offline',
@@ -182,13 +187,13 @@ export const MicrosoftHandleLogin = async () => {
   /**
  * Inscription avec email et mot de passe
  */
-export const registerWithEmail = async (email, password, name) => {
+export const registerWithEmail = async (email, password, name, redirect) => {
   try {
     const { error } = await supabase.auth.signUp({
       email,
       password,
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        emailRedirectTo: buildCallbackUrl(redirect),
       },
     });
     if (error) {
@@ -296,12 +301,12 @@ export const updateUserPassword = async (newPassword) => {
 /**
  * Connexion via Magic Link (OTP)
  */
-export const loginWithMagicLink = async (email) => {
+export const loginWithMagicLink = async (email, redirect) => {
   try {
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: window.location.origin + '/auth/callback',
+        emailRedirectTo: buildCallbackUrl(redirect),
       },
     });
     if (error) {

--- a/frontend/src/utils/redirect.js
+++ b/frontend/src/utils/redirect.js
@@ -1,0 +1,16 @@
+export const getValidRedirect = (redirect) => {
+  if (!redirect) return null;
+
+  try {
+    if (redirect.startsWith('/')) {
+      return redirect;
+    }
+    const url = new URL(redirect);
+    if (url.origin === window.location.origin) {
+      return url.pathname + url.search + url.hash;
+    }
+  } catch (err) {
+    // invalid URL
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- allow optional redirect query when logging in or signing up
- validate redirect paths and forward them to Supabase callbacks
- handle auth callback and navigate to validated redirect

Example login URL that redirects to a shared calendar after authentication:
`https://app.example.com/login?redirect=/shared-calendars`

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `npm install --prefix frontend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6897673559a08328ba740b3fbdbe0e49