### PR TITLE
feat: add wrapper-style calendar verifications

### DIFF
--- a/backend/app/routes/gemini.py
+++ b/backend/app/routes/gemini.py
@@ -3,13 +3,13 @@ from flask import request, g
 from app.utils.auth import require_auth
 from app.utils.responses import success_response, error_response, warning_response
 from app.vertex.gemini import analyze_medical_document
-import time
+from app.utils.measure import measure_time
 
 @api.route("/documents/analyze", methods=["POST"])
 @require_auth
+@measure_time()
 def handle_analyze_medical_document():
     try:
-        t_0 = time.time()
         uid = g.uid
 
         base64_image = request.json.get("image")
@@ -35,15 +35,12 @@ def handle_analyze_medical_document():
                 error="Erreur lors de l'analyse du document médical avec Gemini"
             )
 
-        t_1 = time.time()
-
         return success_response(
             message="document médical analysé avec succès",
             code="DOCUMENT_ANALYZE_SUCCESS",
             uid=uid,
             origin="DOCUMENT_ANALYZE",
-            data={"medicines": analysis_result},
-            log_extra={"time": round(t_1 - t_0, 3)}
+            data={"medicines": analysis_result}
         )
 
     except Exception as e:

--- a/backend/app/routes/gemini.py
+++ b/backend/app/routes/gemini.py
@@ -6,8 +6,8 @@ from app.vertex.gemini import analyze_medical_document
 from app.utils.measure import measure_time
 
 @api.route("/documents/analyze", methods=["POST"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_analyze_medical_document():
     try:
         uid = g.uid

--- a/backend/app/routes/invitations.py
+++ b/backend/app/routes/invitations.py
@@ -16,6 +16,7 @@ from app.services.notifications import email_address_direct
 # Route pour envoyer une invitation à un utilisateur pour un partage de calendrier
 @api.route("/invitations/send/<calendar_id>", methods=["POST"])
 @require_auth
+@verify_calendar
 def handle_send_invitation(calendar_id):
     try:
         t_0 = time.time()
@@ -23,16 +24,6 @@ def handle_send_invitation(calendar_id):
 
         receiver_email = request.get_json(force=True).get("email")
 
-        if not verify_calendar(calendar_id, owner_uid):
-            return warning_response(
-                message="calendrier non trouvé", 
-                code="CALENDAR_NOT_FOUND", 
-                status_code=404, 
-                uid=owner_uid, 
-                origin="INVITATION_SEND",
-                log_extra={"calendar_id": calendar_id}
-            )
-        
         owner = fetch_user(owner_uid)
 
         with get_connection() as conn:

--- a/backend/app/routes/invitations.py
+++ b/backend/app/routes/invitations.py
@@ -5,21 +5,20 @@ from app.db.connection import get_connection
 from app.services.calendar import verify_calendar
 from app.services.user import fetch_user
 from app.services.notifications import notify_and_record
-import time
 from . import api
 from urllib.parse import urljoin
 from app.config import Config
 from app.services.notifications import email_address_direct
-
+from app.utils.measure import measure_time
 
 
 # Route pour envoyer une invitation à un utilisateur pour un partage de calendrier
 @api.route("/invitations/send/<calendar_id>", methods=["POST"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_send_invitation(calendar_id):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
         payload = request.get_json(force=True)
 
@@ -118,15 +117,12 @@ def handle_send_invitation(calendar_id):
                     notification_type="calendar_invitation",
                 )
 
-
-                t_1 = time.time()
-
         return success_response(
             message="invitation envoyée", 
             code="INVITATION_SEND_SUCCESS", 
             uid=owner_uid, 
             origin="INVITATION_SEND",
-            log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -144,9 +140,9 @@ def handle_send_invitation(calendar_id):
 # Route pour accepter une invitation pour un partage de calendrier
 @api.route("/invitations/accept/<notification_id>", methods=["POST"])
 @require_auth
+@measure_time()
 def handle_accept_invitation(notification_id):
     try:
-        t_0 = time.time()
         receiver_uid = g.uid
 
         with get_connection() as conn:
@@ -204,14 +200,12 @@ def handle_accept_invitation(notification_id):
                     notification_type="calendar_invitation_accepted",
                 )
 
-                t_1 = time.time()
-
         return success_response(
             message="invitation acceptée", 
             code="INVITATION_ACCEPT_SUCCESS", 
             uid=receiver_uid, 
             origin="INVITATION_ACCEPT",
-            log_extra={"notification_id": notification_id, "time": t_1 - t_0}
+            log_extra={"notification_id": notification_id}
         )
 
     except Exception as e:
@@ -229,9 +223,9 @@ def handle_accept_invitation(notification_id):
 # Route pour rejeter une invitation pour un partage de calendrier
 @api.route("/invitations/reject/<notification_id>", methods=["POST"])
 @require_auth
+@measure_time()
 def handle_reject_invitation(notification_id):
     try:
-        t_0 = time.time()
         receiver_uid = g.uid
 
         with get_connection() as conn:
@@ -289,14 +283,12 @@ def handle_reject_invitation(notification_id):
                     (receiver_uid, calendar_id)
                 )
 
-                t_1 = time.time()
-
         return success_response(
             message="invitation rejetée", 
             code="INVITATION_REJECT_SUCCESS", 
             uid=receiver_uid, 
             origin="INVITATION_REJECT",
-            log_extra={"notification_id": notification_id, "time": t_1 - t_0}
+            log_extra={"notification_id": notification_id}
         )
 
     except Exception as e:

--- a/backend/app/routes/invitations.py
+++ b/backend/app/routes/invitations.py
@@ -21,10 +21,9 @@ def handle_send_invitation(calendar_id):
     try:
         t_0 = time.time()
         owner_uid = g.uid
+        payload = request.get_json(force=True)
 
-        receiver_email = request.get_json(force=True).get("email")
-
-        owner = fetch_user(owner_uid)
+        receiver_email = payload.get("email")
 
         with get_connection() as conn:
             with conn.cursor() as cursor:

--- a/backend/app/routes/invitations.py
+++ b/backend/app/routes/invitations.py
@@ -14,9 +14,9 @@ from app.utils.measure import measure_time
 
 # Route pour envoyer une invitation à un utilisateur pour un partage de calendrier
 @api.route("/invitations/send/<calendar_id>", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_send_invitation(calendar_id):
     try:
         owner_uid = g.uid
@@ -139,8 +139,8 @@ def handle_send_invitation(calendar_id):
 
 # Route pour accepter une invitation pour un partage de calendrier
 @api.route("/invitations/accept/<notification_id>", methods=["POST"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_accept_invitation(notification_id):
     try:
         receiver_uid = g.uid
@@ -222,8 +222,8 @@ def handle_accept_invitation(notification_id):
 
 # Route pour rejeter une invitation pour un partage de calendrier
 @api.route("/invitations/reject/<notification_id>", methods=["POST"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_reject_invitation(notification_id):
     try:
         receiver_uid = g.uid

--- a/backend/app/routes/notifications.py
+++ b/backend/app/routes/notifications.py
@@ -5,8 +5,8 @@ from app.services.user import fetch_user
 from app.services.calendar import fetch_medicine_name
 from app.db.connection import get_connection
 from flask import request, g
-import time
 from app.config import Config
+from app.utils.measure import measure_time
 
 frontend_url = Config.FRONTEND_URL or ""
 
@@ -31,9 +31,9 @@ def get_user_info(uid):
 # Route pour récupérer toutes les notifications
 @api.route("/notifications", methods=["GET"])
 @require_auth
+@measure_time()
 def handle_notifications():
     try:
-        t_0 = time.time()
         uid = g.uid
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -53,7 +53,6 @@ def handle_notifications():
                 sender_info_cache = {}
                 medication_name_cache = {}
                 notifications = []
-                t_1 = time.time()
 
                 for notif in notifications_data:
                     json_body = notif.get("content") or {}
@@ -97,15 +96,13 @@ def handle_notifications():
                         "medication_name": medication_name,
                         "medication_qty": medication_qty,
                     })
-                t_2 = time.time()
 
         return success_response(
             message="notifications récupérées",
             code="NOTIFICATIONS_FETCH_SUCCESS",
             uid=uid,
             origin="NOTIFICATIONS_FETCH",
-            data={"notifications": notifications},
-            log_extra={"time": t_2 - t_0, "time_append": t_2 - t_1}
+            data={"notifications": notifications}
         )
 
     except Exception as e:
@@ -121,9 +118,9 @@ def handle_notifications():
 # Route pour marquer une notification comme lue
 @api.route("/notifications/<notification_id>", methods=["POST"])
 @require_auth
+@measure_time()
 def handle_read_notification(notification_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         with get_connection() as conn:
@@ -142,14 +139,13 @@ def handle_read_notification(notification_id):
 
                 cursor.execute("UPDATE notifications SET read = TRUE WHERE id = %s AND user_id = %s", (notification_id, uid))
                 conn.commit()
-                t_1 = time.time()
 
         return success_response(
             message="notification marquée comme lue", 
             code="NOTIFICATION_READ_SUCCESS", 
             uid=uid, 
             origin="NOTIFICATION_READ",
-            log_extra={"notification_id": notification_id, "time": t_1 - t_0}
+            log_extra={"notification_id": notification_id}
         )
 
     except Exception as e:
@@ -165,6 +161,7 @@ def handle_read_notification(notification_id):
 # Route pour enregistrer un token FCM
 @api.route("/notifications/register-token", methods=["POST"])
 @require_auth
+@measure_time()
 def register_token():
     data = request.json
     token = data.get("token")

--- a/backend/app/routes/notifications.py
+++ b/backend/app/routes/notifications.py
@@ -30,8 +30,8 @@ def get_user_info(uid):
 
 # Route pour récupérer toutes les notifications
 @api.route("/notifications", methods=["GET"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_notifications():
     try:
         uid = g.uid
@@ -117,8 +117,8 @@ def handle_notifications():
 
 # Route pour marquer une notification comme lue
 @api.route("/notifications/<notification_id>", methods=["POST"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_read_notification(notification_id):
     try:
         uid = g.uid
@@ -160,8 +160,8 @@ def handle_read_notification(notification_id):
 
 # Route pour enregistrer un token FCM
 @api.route("/notifications/register-token", methods=["POST"])
-@require_auth
 @measure_time()
+@require_auth
 def register_token():
     data = request.json
     token = data.get("token")

--- a/backend/app/routes/pdf.py
+++ b/backend/app/routes/pdf.py
@@ -1,16 +1,16 @@
-from flask import request, Response
+from flask import request, Response, g
 import requests
 from app.db.connection import get_connection
 from . import api
 from app.utils.responses import error_response
-import time
 from app.utils.logging import log_backend
-import traceback
+from app.utils.measure import measure_time, elapsed_now
+
 
 @api.route("/proxy/pdf/<box_id>", methods=["GET"])
+@measure_time()
 def proxy_pdf(box_id):
     try:
-        t_0 = time.time()
 
         if not box_id:
             return error_response(
@@ -53,9 +53,15 @@ def proxy_pdf(box_id):
         r = requests.get(url_result["url_notice_fr"], stream=True, timeout=10)
         r.raise_for_status()
 
-        t_1 = time.time()
-
-        log_backend.info(f"PDF downloaded in {t_1 - t_0} seconds", {"origin": "PDF_PROXY", "code": "PDF_DOWNLOADED", "url": url_result["url_notice_fr"]})
+        log_backend.info(
+            f"PDF downloaded", 
+            {
+                "origin": "PDF_PROXY", 
+                "code": "PDF_DOWNLOADED", 
+                "url": url_result["url_notice_fr"], 
+                "time": elapsed_now()
+            }
+        )
 
         return Response(
             r.content,
@@ -63,9 +69,10 @@ def proxy_pdf(box_id):
             headers={"Content-Disposition": "inline; filename=notice.pdf", "Content-Type": "application/pdf"}
         )
     except Exception as e:
-        log_backend.error(f"Error downloading PDF: {e}", {
-            "origin": "PDF_PROXY", 
-            "code": "PDF_DOWNLOAD_ERROR", 
-            "error": traceback.format_exc(),
-        })
-        return f"Erreur lors du téléchargement : {e}", 500
+        return error_response(
+            message="Erreur lors du téléchargement du PDF",
+            code="PDF_DOWNLOAD_ERROR",
+            status_code=500,
+            origin="PDF_PROXY",
+            error=str(e)
+        )

--- a/backend/app/routes/pdf.py
+++ b/backend/app/routes/pdf.py
@@ -7,12 +7,11 @@ import time
 from app.utils.logging import log_backend
 import traceback
 
-@api.route("/proxy/pdf", methods=["GET"])
-def proxy_pdf():
+@api.route("/proxy/pdf/<box_id>", methods=["GET"])
+def proxy_pdf(box_id):
     try:
         t_0 = time.time()
 
-        box_id = request.args.get("box_id")
         if not box_id:
             return error_response(
                 message="Missing box_id",

--- a/backend/app/routes/personnal_calendar.py
+++ b/backend/app/routes/personnal_calendar.py
@@ -16,8 +16,8 @@ ERROR_CALENDAR_NOT_FOUND = "calendrier non trouvé"
 
 # Route pour récupérer les calendriers de l'utilisateur
 @api.route("/calendars", methods=["GET"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_calendars():
     try:
         uid = g.uid
@@ -62,8 +62,8 @@ def handle_calendars():
 
 # Route pour créer un calendrier
 @api.route("/calendars", methods=["POST"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_create_calendar():
     try:
         uid = g.uid
@@ -108,9 +108,9 @@ def handle_create_calendar():
 
 # Route pour supprimer un calendrier
 @api.route("/calendars/<calendar_id>", methods=["DELETE"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_delete_calendar(calendar_id):
     try:
         uid = g.uid
@@ -164,9 +164,9 @@ def handle_delete_calendar(calendar_id):
 
 # Route pour renommer un calendrier
 @api.route("/calendars/<calendar_id>", methods=["PUT"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_rename_calendar(calendar_id):
     try:
         uid = g.uid
@@ -235,9 +235,9 @@ def handle_rename_calendar(calendar_id):
 
 # Route pour générer le calendrier 
 @api.route("/calendars/<calendar_id>/schedule", methods=["GET"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_calendar_schedule(calendar_id):
     try:
         owner_uid = g.uid
@@ -315,9 +315,9 @@ def download_pdf_calendar(calendar_id):
         )
 
 @api.route("/calendars/<calendar_id>/stock-decrement-method", methods=["GET"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def get_personnal_stock_decrement_method(calendar_id):
     try:
         uid = g.uid
@@ -357,9 +357,9 @@ def get_personnal_stock_decrement_method(calendar_id):
 
     
 @api.route("/calendars/<calendar_id>/stock-decrement-method", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def update_personnal_stock_decrement_method(calendar_id):
     try:
         uid = g.uid

--- a/backend/app/routes/personnal_calendar.py
+++ b/backend/app/routes/personnal_calendar.py
@@ -68,7 +68,8 @@ def handle_create_calendar():
     try:
         t_0 = time.time()
         uid = g.uid
-        calendar_name = request.json.get("calendarName")
+        payload = request.get_json(force=True)
+        calendar_name = payload.get("calendarName")
 
         if not calendar_name:
             return warning_response(
@@ -107,14 +108,13 @@ def handle_create_calendar():
 
 
 # Route pour supprimer un calendrier
-@api.route("/calendars", methods=["DELETE"])
+@api.route("/calendars/<calendar_id>", methods=["DELETE"])
 @require_auth
 @verify_calendar
-def handle_delete_calendar():
+def handle_delete_calendar(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        calendar_id = request.json.get("calendarId")
 
         if not calendar_id:
             return warning_response(
@@ -164,16 +164,16 @@ def handle_delete_calendar():
 
 
 # Route pour renommer un calendrier
-@api.route("/calendars", methods=["PUT"])
+@api.route("/calendars/<calendar_id>", methods=["PUT"])
 @require_auth
 @verify_calendar
-def handle_rename_calendar():
+def handle_rename_calendar(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        data = request.get_json(force=True)
-        calendar_id = data.get("calendarId")
-        new_calendar_name = data.get("newCalendarName")
+        payload = request.get_json(force=True)
+
+        new_calendar_name = payload.get("newCalendarName")
 
         if not new_calendar_name:
             return warning_response(
@@ -244,7 +244,8 @@ def handle_calendar_schedule(calendar_id):
         t_0 = time.time()
         owner_uid = g.uid
 
-        start_date = request.args.get("startTime")
+        start_date = request.args.get("startDate")
+
         if not start_date:
             start_date = datetime.now(timezone.utc).date()
         else:
@@ -368,7 +369,9 @@ def update_personnal_stock_decrement_method(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        method = request.json.get("method")
+
+        payload = request.get_json(force=True)
+        method = payload.get("method")
 
         if not method:
             return warning_response(

--- a/backend/app/routes/personnal_calendar.py
+++ b/backend/app/routes/personnal_calendar.py
@@ -109,19 +109,20 @@ def handle_create_calendar():
 # Route pour supprimer un calendrier
 @api.route("/calendars", methods=["DELETE"])
 @require_auth
+@verify_calendar
 def handle_delete_calendar():
     try:
         t_0 = time.time()
         uid = g.uid
         calendar_id = request.json.get("calendarId")
 
-        if not calendar_id or not verify_calendar(calendar_id, uid):
+        if not calendar_id:
             return warning_response(
-                message="identifiant de calendrier invalide", 
-                code="CALENDAR_DELETE_ERROR", 
-                status_code=400, 
-                uid=uid, 
-                origin="CALENDAR_DELETE_ERROR", 
+                message="identifiant de calendrier invalide",
+                code="CALENDAR_DELETE_ERROR",
+                status_code=400,
+                uid=uid,
+                origin="CALENDAR_DELETE_ERROR",
                 log_extra={"calendar_id": calendar_id}
             )
 
@@ -165,6 +166,7 @@ def handle_delete_calendar():
 # Route pour renommer un calendrier
 @api.route("/calendars", methods=["PUT"])
 @require_auth
+@verify_calendar
 def handle_rename_calendar():
     try:
         t_0 = time.time()
@@ -173,19 +175,9 @@ def handle_rename_calendar():
         calendar_id = data.get("calendarId")
         new_calendar_name = data.get("newCalendarName")
 
-        if not verify_calendar(calendar_id, uid):
-            return warning_response(
-                message="accès refusé", 
-                code="ACCESS_DENIED", 
-                status_code=400, 
-                uid=uid, 
-                origin="CALENDAR_RENAME", 
-                log_extra={"calendar_id": calendar_id, "new_calendar_name": new_calendar_name}
-            )
-
         if not new_calendar_name:
             return warning_response(
-                message="nom de calendrier manquant", 
+                message="nom de calendrier manquant",
                 code="CALENDAR_RENAME_ERROR", 
                 status_code=400, 
                 uid=uid, 
@@ -246,6 +238,7 @@ def handle_rename_calendar():
 # Route pour générer le calendrier 
 @api.route("/calendars/<calendar_id>/schedule", methods=["GET"])
 @require_auth
+@verify_calendar
 def handle_calendar_schedule(calendar_id):
     try:
         t_0 = time.time()
@@ -256,16 +249,6 @@ def handle_calendar_schedule(calendar_id):
             start_date = datetime.now(timezone.utc).date()
         else:
             start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
-
-        if not verify_calendar(calendar_id, owner_uid):
-            return warning_response(
-                message="accès refusé", 
-                code="ACCESS_DENIED", 
-                status_code=400, 
-                uid=owner_uid, 
-                origin="CALENDAR_GENERATE", 
-                log_extra={"calendar_id": calendar_id}
-            )
 
         schedule, table, calendar_name = generate_calendar_schedule(calendar_id, start_date)
 
@@ -297,35 +280,7 @@ def handle_calendar_schedule(calendar_id):
 def download_pdf_calendar(calendar_id):
     try:
         t_0 = time.time()
-        # TODO: Secirisé cette route
-        """        token = request.args.get("token")
-                if not token:
-                    return error_response(
-                        message="token manquant",
-                        code="MISSING_TOKEN",
-                        status_code=400,
-                        origin="PDF_DOWNLOAD"
-                    )
-
-                user = decode_token(token)
-                if not user:
-                    return warning_response(
-                        message="accès refusé", 
-                        code="ACCESS_DENIED", 
-                        status_code=400, 
-                        origin="PDF_DOWNLOAD", 
-                        log_extra={"calendar_id": calendar_id}
-                    )
-                uid = user.get("sub")
-                if not verify_calendar(calendar_id, uid):
-                    return warning_response(
-                        message="accès refusé", 
-                        code="ACCESS_DENIED", 
-                        status_code=400, 
-                        origin="PDF_DOWNLOAD", 
-                        log_extra={"calendar_id": calendar_id}
-                    )
-        """
+        # TODO: Sécuriser cette route
 
         if not calendar_id:
             return error_response(
@@ -366,19 +321,11 @@ def download_pdf_calendar(calendar_id):
 
 @api.route("/calendars/<calendar_id>/stock-decrement-method", methods=["GET"])
 @require_auth
+@verify_calendar
 def get_personnal_stock_decrement_method(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        if not verify_calendar(calendar_id, uid):
-            return warning_response(
-                message="accès refusé", 
-                code="ACCESS_DENIED",
-                status_code=400,
-                uid=uid,
-                origin="STOCK_DECREMENT_METHOD_FETCH",
-                log_extra={"calendar_id": calendar_id}
-            )
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("SELECT stock_decrement_method FROM calendars WHERE id = %s", (calendar_id,))
@@ -416,6 +363,7 @@ def get_personnal_stock_decrement_method(calendar_id):
     
 @api.route("/calendars/<calendar_id>/stock-decrement-method", methods=["POST"])
 @require_auth
+@verify_calendar
 def update_personnal_stock_decrement_method(calendar_id):
     try:
         t_0 = time.time()
@@ -424,23 +372,14 @@ def update_personnal_stock_decrement_method(calendar_id):
 
         if not method:
             return warning_response(
-                message="method manquant", 
-                code="STOCK_DECREMENT_METHOD_UPDATE_ERROR", 
-                status_code=400, 
-                uid=uid, 
-                origin="STOCK_DECREMENT_METHOD_UPDATE", 
+                message="method manquant",
+                code="STOCK_DECREMENT_METHOD_UPDATE_ERROR",
+                status_code=400,
+                uid=uid,
+                origin="STOCK_DECREMENT_METHOD_UPDATE",
                 log_extra={"calendar_id": calendar_id}
             )
 
-        if not verify_calendar(calendar_id, uid):
-            return warning_response(
-                message="accès refusé", 
-                code="ACCESS_DENIED", 
-                status_code=400, 
-                uid=uid, 
-                origin="STOCK_DECREMENT_METHOD_UPDATE", 
-                log_extra={"calendar_id": calendar_id}
-            )
         uptate_stock_decrement_method(calendar_id, method)
         t_1 = time.time()
         return success_response(
@@ -461,52 +400,3 @@ def update_personnal_stock_decrement_method(calendar_id):
             log_extra={"calendar_id": calendar_id}
         )
 
-"""@api.route("/calendars/<calendar_id>/notifications", methods=["GET"])
-@require_auth
-def fetch_personal_notifications_enabled(calendar_id):
-    try:
-        t_0 = time.time()
-        uid = g.uid
-        if not verify_calendar(calendar_id, uid):
-            return warning_response(
-                message="accès refusé", 
-                code="ACCESS_DENIED", 
-                status_code=400, 
-                uid=uid, 
-                origin="NOTIFICATIONS_FETCH", 
-                log_extra={"calendar_id": calendar_id}
-            )
-        with get_connection() as conn:
-            with conn.cursor() as cursor:
-                cursor.execute("SELECT notifications_enabled FROM calendars WHERE id = %s", (calendar_id,))
-                result = cursor.fetchone()
-                if result is None:
-                    return warning_response(
-                        message=ERROR_CALENDAR_NOT_FOUND,
-                        code="NOTIFICATIONS_FETCH_ERROR",
-                        status_code=404,
-                        uid=uid,
-                        origin="NOTIFICATIONS_FETCH",
-                        log_extra={"calendar_id": calendar_id}
-                    )
-                notifications_enabled = result.get("notifications_enabled", False)
-        t_1 = time.time()
-        return success_response(
-            message="notifications récupérées",
-            code="NOTIFICATIONS_FETCH_SUCCESS",
-            uid=uid,
-            origin="NOTIFICATIONS_FETCH",
-            data={"notifications_enabled": notifications_enabled},
-            log_extra={"calendar_id": calendar_id, "notifications-enabled": notifications_enabled, "time": t_1 - t_0}
-        )
-    except Exception as e:
-        return error_response(
-            message="erreur lors de la récupération des notifications",
-            code="NOTIFICATIONS_FETCH_ERROR",
-            status_code=500,
-            uid=uid,
-            origin="NOTIFICATIONS_FETCH",
-            error=str(e),
-            log_extra={"calendar_id": calendar_id}
-        )
-"""

--- a/backend/app/routes/personnal_calendar.py
+++ b/backend/app/routes/personnal_calendar.py
@@ -5,20 +5,21 @@ from flask import request, g, Response
 from app.db.connection import get_connection
 from app.services.calendar import generate_calendar_schedule, uptate_stock_decrement_method
 from app.services.calendar import verify_calendar
-import time
 from app.utils.responses import success_response, error_response, warning_response
 from app.utils.logging import log_backend
 from app.services.documents import generate_medicine_conditions_pdf
 from app.services.medication import check_if_stock_is_low
+from app.utils.measure import measure_time, elapsed_now
+
 
 ERROR_CALENDAR_NOT_FOUND = "calendrier non trouvé"
 
 # Route pour récupérer les calendriers de l'utilisateur
 @api.route("/calendars", methods=["GET"])
 @require_auth
+@measure_time()
 def handle_calendars():
     try:
-        t_0 = time.time()
         uid = g.uid
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -41,14 +42,12 @@ def handle_calendars():
                     if_low_stock = check_if_stock_is_low(calendar["id"])
                     calendar["ifLowStock"] = if_low_stock
 
-        t_1 = time.time()
         return success_response(
             message="calendriers récupérés", 
             code="CALENDAR_FETCH_SUCCESS", 
             uid=uid, 
             origin="CALENDAR_FETCH", 
             data={"calendars": calendars},
-            log_extra={"time": t_1 - t_0}
         )
     except Exception as e:
         return error_response(
@@ -64,9 +63,9 @@ def handle_calendars():
 # Route pour créer un calendrier
 @api.route("/calendars", methods=["POST"])
 @require_auth
+@measure_time()
 def handle_create_calendar():
     try:
-        t_0 = time.time()
         uid = g.uid
         payload = request.get_json(force=True)
         calendar_name = payload.get("calendarName")
@@ -86,14 +85,14 @@ def handle_create_calendar():
                 cursor.execute("INSERT INTO calendars (owner_uid, name) VALUES (%s, %s) RETURNING id", (uid, calendar_name))
                 calendar_id = cursor.fetchone().get("id")
                 conn.commit()
-        t_1 = time.time()
+
         return success_response(
             message="calendrier créé", 
             code="CALENDAR_CREATE", 
             uid=uid, 
             origin="CALENDAR_CREATE",
             data={"calendarId": calendar_id, "calendarName": calendar_name},
-            log_extra={"calendar_name": calendar_name, "time": t_1 - t_0}
+            log_extra={"calendar_name": calendar_name}
         )
 
     except Exception as e:
@@ -111,9 +110,9 @@ def handle_create_calendar():
 @api.route("/calendars/<calendar_id>", methods=["DELETE"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_delete_calendar(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         if not calendar_id:
@@ -130,7 +129,7 @@ def handle_delete_calendar(calendar_id):
             with conn.cursor() as cursor:
                 cursor.execute("SELECT * FROM calendars WHERE id = %s", (calendar_id,))
                 calendar = cursor.fetchone()
-                t_1 = time.time()
+                
                 if calendar is None:
                     return warning_response(
                         message=ERROR_CALENDAR_NOT_FOUND, 
@@ -138,18 +137,18 @@ def handle_delete_calendar(calendar_id):
                         status_code=404, 
                         uid=uid, 
                         origin="CALENDAR_DELETE_ERROR", 
-                        log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+                        log_extra={"calendar_id": calendar_id}
                     )
 
                 cursor.execute("DELETE FROM calendars WHERE id = %s", (calendar_id,))
                 conn.commit()
-        t_2 = time.time()
+
         return success_response(
             message="calendrier supprimé", 
             code="CALENDAR_DELETE_SUCCESS", 
             uid=uid, 
             origin="CALENDAR_DELETE", 
-            log_extra={"calendar_id": calendar_id, "time": t_2 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -167,9 +166,9 @@ def handle_delete_calendar(calendar_id):
 @api.route("/calendars/<calendar_id>", methods=["PUT"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_rename_calendar(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
         payload = request.get_json(force=True)
 
@@ -216,13 +215,12 @@ def handle_rename_calendar(calendar_id):
                 )
                 conn.commit()
 
-        t_1 = time.time()
         return success_response(
             message="calendrier renommé", 
             code="CALENDAR_RENAME_SUCCESS", 
             uid=uid, 
             origin="CALENDAR_RENAME", 
-            log_extra={"calendar_id": calendar_id, "old_calendar_name": old_name, "new_calendar_name": new_calendar_name, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id, "old_calendar_name": old_name, "new_calendar_name": new_calendar_name}
         )
 
     except Exception as e:
@@ -239,9 +237,9 @@ def handle_rename_calendar(calendar_id):
 @api.route("/calendars/<calendar_id>/schedule", methods=["GET"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_calendar_schedule(calendar_id):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
 
         start_date = request.args.get("startDate")
@@ -255,15 +253,13 @@ def handle_calendar_schedule(calendar_id):
 
         if_low_stock = check_if_stock_is_low(calendar_id)
 
-        t_1 = time.time()
-
         return success_response(
             message="calendrier généré", 
             code="CALENDAR_GENERATE_SUCCESS", 
             uid=owner_uid, 
             origin="CALENDAR_GENERATE", 
             data={"schedule": schedule, "table": table, "calendar_name": calendar_name, "if_low_stock": if_low_stock},
-            log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -278,9 +274,9 @@ def handle_calendar_schedule(calendar_id):
         )
 
 @api.route("/calendars/<calendar_id>/pdf", methods=["GET"])
+@measure_time()
 def download_pdf_calendar(calendar_id):
     try:
-        t_0 = time.time()
         # TODO: Sécuriser cette route
 
         if not calendar_id:
@@ -293,14 +289,12 @@ def download_pdf_calendar(calendar_id):
 
         # Génère le PDF en mémoire
         pdf_buffer = generate_medicine_conditions_pdf(calendar_id)
-        t_1 = time.time()
 
         # Log facultatif
         log_backend.info("PDF généré avec succès", {
             "origin": "PDF_DOWNLOAD",
-            "uid": "unknown",
             "code": "PDF_DOWNLOAD_SUCCESS",
-            "time": round(t_1 - t_0, 3),
+            "time": elapsed_now()
         })
 
         return Response(
@@ -323,9 +317,9 @@ def download_pdf_calendar(calendar_id):
 @api.route("/calendars/<calendar_id>/stock-decrement-method", methods=["GET"])
 @require_auth
 @verify_calendar
+@measure_time()
 def get_personnal_stock_decrement_method(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -341,14 +335,14 @@ def get_personnal_stock_decrement_method(calendar_id):
                         log_extra={"calendar_id": calendar_id}
                     )
                 method = result.get("stock_decrement_method")
-        t_1 = time.time()
+
         return success_response(
             message="méthode de diminution de stock récupérée",
             code="STOCK_DECREMENT_METHOD_FETCH_SUCCESS",
             uid=uid,
             origin="STOCK_DECREMENT_METHOD_FETCH",
             data={"method": method},
-            log_extra={"calendar_id": calendar_id, "method": method, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id, "method": method}
         )
     except Exception as e:
         return error_response(
@@ -365,9 +359,9 @@ def get_personnal_stock_decrement_method(calendar_id):
 @api.route("/calendars/<calendar_id>/stock-decrement-method", methods=["POST"])
 @require_auth
 @verify_calendar
+@measure_time()
 def update_personnal_stock_decrement_method(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         payload = request.get_json(force=True)
@@ -384,13 +378,13 @@ def update_personnal_stock_decrement_method(calendar_id):
             )
 
         uptate_stock_decrement_method(calendar_id, method)
-        t_1 = time.time()
+
         return success_response(
             message="methode de diminution de stock mise à jour", 
             code="STOCK_DECREMENT_METHOD_UPDATE_SUCCESS",
             uid=uid,
             origin="STOCK_DECREMENT_METHOD_UPDATE",
-            log_extra={"calendar_id": calendar_id, "method": method, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id, "method": method}
         )
     except Exception as e:
         return error_response(

--- a/backend/app/routes/personnal_medicines.py
+++ b/backend/app/routes/personnal_medicines.py
@@ -12,9 +12,9 @@ ERROR_UNAUTHORIZED_ACCESS = "accès refusé"
 
 # Route pour récupérer les boites de médicaments d'un calendrier
 @api.route("/calendars/<calendar_id>/boxes", methods=["GET"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_boxes(calendar_id):
     try:
         uid = g.uid
@@ -44,9 +44,9 @@ def handle_boxes(calendar_id):
 
 # Route pour modifier une boite de médicaments
 @api.route("/calendars/<calendar_id>/boxes/<box_id>", methods=["PUT"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_update_box(calendar_id, box_id):
     try:
         uid = g.uid
@@ -87,9 +87,9 @@ def handle_update_box(calendar_id, box_id):
 
 # Route pour créer une boite de médicaments
 @api.route("/calendars/<calendar_id>/boxes", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_create_box(calendar_id):
     try:
         uid = g.uid
@@ -131,9 +131,9 @@ def handle_create_box(calendar_id):
 
 # Route pour supprimer une boite de médicaments
 @api.route("/calendars/<calendar_id>/boxes/<box_id>", methods=["DELETE"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_delete_box(calendar_id, box_id):
     try:
         uid = g.uid
@@ -160,9 +160,9 @@ def handle_delete_box(calendar_id, box_id):
         )
 
 @api.route("/calendars/<calendar_id>/pilluliers/used", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_use_pillulier(calendar_id):
     try:
         uid = g.uid
@@ -214,9 +214,9 @@ def handle_use_pillulier(calendar_id):
         )
     
 @api.route("/calendars/<calendar_id>/boxes/<box_id>/restock", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_restock_box(calendar_id, box_id):
     try:
         uid = g.uid

--- a/backend/app/routes/personnal_medicines.py
+++ b/backend/app/routes/personnal_medicines.py
@@ -1,12 +1,12 @@
 from flask import request, g
 from app.utils.auth import require_auth
-import time
 from . import api
 from app.services.calendar import verify_calendar
 from app.services.medication import update_box, create_box, delete_box, get_boxes, restock_box
 from app.utils.responses import success_response, error_response, warning_response
 from app.services.medication import use_pillulier
 from datetime import datetime, timezone
+from app.utils.measure import measure_time
 
 ERROR_UNAUTHORIZED_ACCESS = "accès refusé"
 
@@ -14,13 +14,12 @@ ERROR_UNAUTHORIZED_ACCESS = "accès refusé"
 @api.route("/calendars/<calendar_id>/boxes", methods=["GET"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_boxes(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         boxes = get_boxes(calendar_id)
-        t_1 = time.time()
 
         return success_response(
             message="boites de médicaments récupérées",
@@ -28,7 +27,7 @@ def handle_boxes(calendar_id):
             uid=uid,
             origin="GET_MEDICINE_BOXES",
             data={"boxes": boxes},
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id, "boxes_count": len(boxes) if boxes is not None else 0}
+            log_extra={"calendar_id": calendar_id, "boxes_count": len(boxes) if boxes is not None else 0}
         )
 
     except Exception as e:
@@ -47,9 +46,9 @@ def handle_boxes(calendar_id):
 @api.route("/calendars/<calendar_id>/boxes/<box_id>", methods=["PUT"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_update_box(calendar_id, box_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         payload = request.get_json(force=True)
@@ -67,14 +66,12 @@ def handle_update_box(calendar_id, box_id):
 
         update_box(box_id, calendar_id, box)
         
-        t_1 = time.time()
-        
         return success_response(
             message="boite de médicaments modifiée",
             code="MEDICINE_BOX_UPDATED",
             uid=uid,
             origin="UPDATE_MEDICINE_BOX",
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id, "box_id": box_id}
+            log_extra={"calendar_id": calendar_id, "box_id": box_id}
         )
 
     except Exception as e:
@@ -92,9 +89,9 @@ def handle_update_box(calendar_id, box_id):
 @api.route("/calendars/<calendar_id>/boxes", methods=["POST"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_create_box(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         payload = request.get_json(force=True)
@@ -112,14 +109,13 @@ def handle_create_box(calendar_id):
 
         box_id = create_box(calendar_id, box)
 
-        t_1 = time.time()
         return success_response(
             message="boite de médicaments créée",
             code="MEDICINE_BOX_CREATED",
             uid=uid,
             origin="CREATE_MEDICINE_BOX",
             data={"box_id": box_id},
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -137,19 +133,19 @@ def handle_create_box(calendar_id):
 @api.route("/calendars/<calendar_id>/boxes/<box_id>", methods=["DELETE"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_delete_box(calendar_id, box_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         delete_box(box_id, calendar_id)
-        t_1 = time.time()
+        
         return success_response(
             message="boite de médicaments supprimée",
             code="MEDICINE_BOX_DELETED",
             uid=uid,
             origin="DELETE_MEDICINE_BOX",
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id, "box_id": box_id}
+            log_extra={"calendar_id": calendar_id, "box_id": box_id}
         )
 
     except Exception as e:
@@ -166,9 +162,9 @@ def handle_delete_box(calendar_id, box_id):
 @api.route("/calendars/<calendar_id>/pilluliers/used", methods=["POST"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_use_pillulier(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
         
         payload = request.get_json(force=True)
@@ -181,7 +177,6 @@ def handle_use_pillulier(calendar_id):
 
         result = use_pillulier(calendar_id, start_date)
 
-        t_1 = time.time()
         if result == False:
             return warning_response(
                 message="aucun médicament à utiliser",
@@ -205,7 +200,7 @@ def handle_use_pillulier(calendar_id):
             code="PILLULIER_MEDICATION_USED",
             uid=uid,
             origin="USE_PILLULIER_MEDICATION",
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id}
+            log_extra={"calendar_id": calendar_id}
         )
     except Exception as e:
         return error_response(
@@ -221,9 +216,9 @@ def handle_use_pillulier(calendar_id):
 @api.route("/calendars/<calendar_id>/boxes/<box_id>/restock", methods=["POST"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_restock_box(calendar_id, box_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         if not restock_box(box_id, calendar_id):
@@ -235,7 +230,6 @@ def handle_restock_box(calendar_id, box_id):
                 origin="RESTOCK_MEDICINE_BOX",
                 log_extra={"calendar_id": calendar_id, "box_id": box_id}
             )
-        t_1 = time.time()
 
         return success_response(
             message="boite de médicaments réapprovisionnée",
@@ -243,7 +237,7 @@ def handle_restock_box(calendar_id, box_id):
             uid=uid,
             origin="RESTOCK_MEDICINE_BOX",
             data={"box_id": box_id},
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id, "box_id": box_id}
+            log_extra={"calendar_id": calendar_id, "box_id": box_id}
         )
     except Exception as e:
         return error_response(

--- a/backend/app/routes/personnal_medicines.py
+++ b/backend/app/routes/personnal_medicines.py
@@ -13,20 +13,12 @@ ERROR_UNAUTHORIZED_ACCESS = "accès refusé"
 # Route pour récupérer les boites de médicaments d'un calendrier
 @api.route("/calendars/<calendar_id>/boxes", methods=["GET"])
 @require_auth
+@verify_calendar
 def handle_boxes(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
 
-        if not verify_calendar(calendar_id, uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="UNAUTHORIZED_ACCESS",
-                status_code=404,
-                uid=uid,
-                origin="GET_MEDICINE_BOXES",
-                log_extra={"calendar_id": calendar_id}
-            )
         boxes = get_boxes(calendar_id)
         t_1 = time.time()
 
@@ -54,6 +46,7 @@ def handle_boxes(calendar_id):
 # Route pour modifier une boite de médicaments
 @api.route("/calendars/<calendar_id>/boxes/<box_id>", methods=["PUT"])
 @require_auth
+@verify_calendar
 def handle_update_box(calendar_id, box_id):
     try:
         t_0 = time.time()
@@ -61,7 +54,7 @@ def handle_update_box(calendar_id, box_id):
 
         data = request.get_json()
 
-        if not data or not verify_calendar(calendar_id, uid):
+        if not data:
             return warning_response(
                 message="champs requis manquants",
                 code="MISSING_REQUIRED_FIELDS",
@@ -97,6 +90,7 @@ def handle_update_box(calendar_id, box_id):
 # Route pour créer une boite de médicaments
 @api.route("/calendars/<calendar_id>/boxes", methods=["POST"])
 @require_auth
+@verify_calendar
 def handle_create_box(calendar_id):
     try:
         t_0 = time.time()
@@ -104,7 +98,7 @@ def handle_create_box(calendar_id):
 
         data = request.get_json()
 
-        if not data or not verify_calendar(calendar_id, uid):
+        if not data:
             return warning_response(
                 message="champs requis manquants",
                 code="MISSING_REQUIRED_FIELDS",
@@ -140,20 +134,11 @@ def handle_create_box(calendar_id):
 # Route pour supprimer une boite de médicaments
 @api.route("/calendars/<calendar_id>/boxes/<box_id>", methods=["DELETE"])
 @require_auth
+@verify_calendar
 def handle_delete_box(calendar_id, box_id):
     try:
         t_0 = time.time()
         uid = g.uid
-
-        if not verify_calendar(calendar_id, uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="UNAUTHORIZED_ACCESS",
-                status_code=404,
-                uid=uid,
-                origin="DELETE_MEDICINE_BOX",
-                log_extra={"calendar_id": calendar_id}
-            )
 
         delete_box(box_id, calendar_id)
         t_1 = time.time()
@@ -178,6 +163,7 @@ def handle_delete_box(calendar_id, box_id):
 
 @api.route("/calendars/<calendar_id>/pilluliers/used", methods=["POST"])
 @require_auth
+@verify_calendar
 def handle_use_pillulier(calendar_id):
     try:
         t_0 = time.time()
@@ -187,16 +173,6 @@ def handle_use_pillulier(calendar_id):
             start_date = datetime.now(timezone.utc).date()
         else:
             start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
-        
-        if not verify_calendar(calendar_id, uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="UNAUTHORIZED_ACCESS",
-                status_code=404,
-                uid=uid,
-                origin="USE_PILLULIER_MEDICATION",
-                log_extra={"calendar_id": calendar_id}
-            )
 
         result = use_pillulier(calendar_id, start_date)
 
@@ -239,20 +215,11 @@ def handle_use_pillulier(calendar_id):
     
 @api.route("/calendars/<calendar_id>/boxes/<box_id>/restock", methods=["POST"])
 @require_auth
+@verify_calendar
 def handle_restock_box(calendar_id, box_id):
     try:
         t_0 = time.time()
         uid = g.uid
-
-        if not verify_calendar(calendar_id, uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="UNAUTHORIZED_ACCESS",
-                status_code=404,
-                uid=uid,
-                origin="RESTOCK_MEDICINE_BOX",
-                log_extra={"calendar_id": calendar_id, "box_id": box_id}
-            )
 
         if not restock_box(box_id, calendar_id):
             return warning_response(

--- a/backend/app/routes/personnal_medicines.py
+++ b/backend/app/routes/personnal_medicines.py
@@ -52,9 +52,10 @@ def handle_update_box(calendar_id, box_id):
         t_0 = time.time()
         uid = g.uid
 
-        data = request.get_json()
+        payload = request.get_json(force=True)
+        box = payload.get("box")
 
-        if not data:
+        if not box:
             return warning_response(
                 message="champs requis manquants",
                 code="MISSING_REQUIRED_FIELDS",
@@ -64,7 +65,7 @@ def handle_update_box(calendar_id, box_id):
                 log_extra={"calendar_id": calendar_id, "box_id": box_id}
             )
 
-        update_box(box_id, calendar_id, data)
+        update_box(box_id, calendar_id, box)
         
         t_1 = time.time()
         
@@ -96,9 +97,10 @@ def handle_create_box(calendar_id):
         t_0 = time.time()
         uid = g.uid
 
-        data = request.get_json()
+        payload = request.get_json(force=True)
+        box = payload.get("box")
 
-        if not data:
+        if not box:
             return warning_response(
                 message="champs requis manquants",
                 code="MISSING_REQUIRED_FIELDS",
@@ -108,7 +110,7 @@ def handle_create_box(calendar_id):
                 log_extra={"calendar_id": calendar_id}
             )
 
-        box_id = create_box(calendar_id, data)
+        box_id = create_box(calendar_id, box)
 
         t_1 = time.time()
         return success_response(
@@ -168,7 +170,10 @@ def handle_use_pillulier(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        start_date = request.args.get("startTime")
+        
+        payload = request.get_json(force=True)
+        start_date = payload.get("startTime")
+        
         if not start_date:
             start_date = datetime.now(timezone.utc).date()
         else:

--- a/backend/app/routes/shared_users.py
+++ b/backend/app/routes/shared_users.py
@@ -196,7 +196,8 @@ def handle_user_shared_calendar_schedule(calendar_id):
         t_0 = time.time()
         uid = g.uid
 
-        start_date = request.args.get("startTime")
+        start_date = request.args.get("startDate")
+
         if not start_date:
             start_date = datetime.now(timezone.utc).date()
         else:
@@ -525,6 +526,7 @@ def handle_shared_user_notifications(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
+        
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("SELECT notifications_enabled FROM shared_calendars WHERE calendar_id = %s", (calendar_id,))
@@ -566,8 +568,11 @@ def handle_shared_user_notifications_update(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        data = request.get_json()
-        if not data or "notifications-enabled" not in data:
+
+        payload = request.get_json(force=True)
+        notifications_enabled = payload.get("notifications-enabled")
+
+        if not notifications_enabled:
             return warning_response(
                 message="Données manquantes",
                 code="SHARED_CALENDARS_NOTIFICATIONS_ERROR",
@@ -576,7 +581,6 @@ def handle_shared_user_notifications_update(calendar_id):
                 origin="SHARED_CALENDARS_NOTIFICATIONS",
                 log_extra={"calendar_id": calendar_id}
             )
-        notifications_enabled = data["notifications-enabled"]
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("UPDATE shared_calendars SET notifications_enabled = %s WHERE calendar_id = %s", (notifications_enabled, calendar_id))

--- a/backend/app/routes/shared_users.py
+++ b/backend/app/routes/shared_users.py
@@ -3,7 +3,6 @@ from datetime import datetime, timezone
 from . import api
 from app.services.calendar import verify_calendar_share, verify_calendar, generate_calendar_schedule
 from flask import request, g
-import time
 from app.services.user import fetch_user
 from app.utils.responses import success_response, error_response, warning_response
 from app.db.connection import get_connection
@@ -13,6 +12,7 @@ from app.config import Config
 from urllib.parse import urljoin
 from app.services.medication import check_if_stock_is_low
 from app.services.notifications import email_address_direct
+from app.utils.measure import measure_time
 
 
 ERROR_CALENDAR_NOT_FOUND = "calendrier non trouvé"
@@ -24,16 +24,15 @@ SELECT_SHARED_CALENDAR = "SELECT * FROM calendars WHERE id = %s"
 # Route pour récupérer les calendriers partagés
 @api.route("/shared/users/calendars", methods=["GET"])
 @require_auth
+@measure_time()
 def handle_shared_calendars():
     try:
-        t_0 = time.time()
         uid = g.uid
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("SELECT * FROM shared_calendars WHERE receiver_uid = %s AND accepted = true", (uid,))
                 shared_users = cursor.fetchall()
-                t_1 = time.time()
 
                 if not shared_users:
                     return success_response(
@@ -41,8 +40,7 @@ def handle_shared_calendars():
                         code="SHARED_CALENDARS_LOAD_EMPTY", 
                         uid=uid,
                         origin="SHARED_CALENDARS_LOAD",
-                        data={"calendars": []},
-                        log_extra={"time": t_1 - t_0}
+                        data={"calendars": []}
                     )
 
                 calendars_list = []
@@ -107,15 +105,12 @@ def handle_shared_calendars():
                         "ifLowStock": if_low_stock
                     })
 
-                t_2 = time.time()
-
                 return success_response(
                     message=SUCCESS_SHARED_CALENDARS_LOAD, 
                     code="SHARED_CALENDARS_LOAD_SUCCESS", 
                     uid=uid, 
                     origin="SHARED_CALENDARS_LOAD",
-                    data={"calendars": calendars_list},
-                    log_extra={"time": t_2 - t_0}
+                    data={"calendars": calendars_list}
                 )
 
     except Exception as e:
@@ -132,10 +127,10 @@ def handle_shared_calendars():
 @api.route("/shared/users/calendars/<calendar_id>", methods=["GET"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_user_shared_calendar(calendar_id):
     try:
-        t_0 = time.time()
-        receiver_uid = g.uid
+        uid = g.uid
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -146,7 +141,7 @@ def handle_user_shared_calendar(calendar_id):
                         message=ERROR_CALENDAR_NOT_FOUND,
                         code="SHARED_CALENDARS_LOAD_ERROR",
                         status_code=404,
-                        uid=receiver_uid,
+                        uid=uid,
                         origin="SHARED_CALENDARS_LOAD",
                         log_extra={"calendar_id": calendar_id}
                     )
@@ -161,20 +156,19 @@ def handle_user_shared_calendar(calendar_id):
                         message=ERROR_CALENDAR_NOT_FOUND,
                         code="SHARED_CALENDARS_LOAD_ERROR",
                         status_code=404,
-                        uid=receiver_uid,
+                        uid=uid,
                         origin="SHARED_CALENDARS_LOAD",
                         log_extra={"calendar_id": calendar_id}
                     )
                 access = shared_user.get("access", "read")
-                t_2 = time.time()
 
         return success_response(
             message=SUCCESS_SHARED_CALENDARS_LOAD,
             code="SHARED_CALENDARS_LOAD_SUCCESS",
-            uid=receiver_uid,
+            uid=uid,
             origin="SHARED_CALENDARS_LOAD",
             data={"calendar_id": calendar_id, "calendar_name": calendar_name, "access": access, "owner_uid": owner_uid},
-            log_extra={"calendar_id": calendar_id, "time": t_2 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -182,7 +176,7 @@ def handle_user_shared_calendar(calendar_id):
             message="erreur lors de la récupération du calendrier partagé",
             code="SHARED_CALENDARS_ERROR",
             status_code=500,
-            uid=receiver_uid,
+            uid=uid,
             origin="SHARED_CALENDARS_LOAD",
             error=str(e),
             log_extra={"calendar_id": calendar_id}
@@ -191,9 +185,9 @@ def handle_user_shared_calendar(calendar_id):
 @api.route("/shared/users/calendars/<calendar_id>/schedule", methods=["GET"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_user_shared_calendar_schedule(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         start_date = request.args.get("startDate")
@@ -207,15 +201,13 @@ def handle_user_shared_calendar_schedule(calendar_id):
 
         if_low_stock = check_if_stock_is_low(calendar_id)
 
-        t_1 = time.time()
-            
         return success_response(
             message=SUCCESS_SHARED_CALENDARS_LOAD, 
             code="SHARED_CALENDARS_LOAD_SUCCESS", 
             uid=uid, 
             origin="SHARED_CALENDARS_LOAD",
             data={"schedule": schedule, "table": table, "calendar_name": calendar_name, "if_low_stock": if_low_stock},
-            log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -234,9 +226,9 @@ def handle_user_shared_calendar_schedule(calendar_id):
 @api.route("/shared/users/calendars/<calendar_id>", methods=["DELETE"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_delete_user_shared_calendar(calendar_id):
     try:
-        t_0 = time.time()
         receiver_uid = g.uid
 
         with get_connection() as conn:
@@ -266,14 +258,13 @@ def handle_delete_user_shared_calendar(calendar_id):
                     },
                     notification_type="calendar_shared_deleted_by_receiver",
                 )
-                t_1 = time.time()
 
         return success_response(
             message="calendrier partagé supprimé", 
             code="SHARED_CALENDARS_DELETE_SUCCESS", 
             uid=receiver_uid, 
             origin="SHARED_CALENDARS_DELETE",
-            log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -292,9 +283,9 @@ def handle_delete_user_shared_calendar(calendar_id):
 @api.route("/shared/users/<calendar_id>/<receiver_uid>", methods=["DELETE"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_delete_user_shared_user(calendar_id, receiver_uid):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
 
         if owner_uid == receiver_uid:
@@ -352,14 +343,13 @@ def handle_delete_user_shared_user(calendar_id, receiver_uid):
                     },
                     notification_type="calendar_shared_deleted_by_owner",
                 )
-                t_1 = time.time()
 
         return success_response(
             message="utilisateur partagé supprimé", 
             code="SHARED_USERS_DELETE_SUCCESS", 
-            uid=receiver_uid, 
+            uid=owner_uid, 
             origin="SHARED_USERS_DELETE",
-            log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -367,7 +357,7 @@ def handle_delete_user_shared_user(calendar_id, receiver_uid):
             message="erreur lors de la suppression de l'utilisateur partagé",
             code="SHARED_USERS_DELETE_ERROR", 
             status_code=500, 
-            uid=receiver_uid, 
+            uid=owner_uid, 
             origin="SHARED_USERS_DELETE",
             error=str(e),
             log_extra={"calendar_id": calendar_id}
@@ -378,9 +368,9 @@ def handle_delete_user_shared_user(calendar_id, receiver_uid):
 @api.route("/invitations/<calendar_id>", methods=["DELETE"])
 @require_auth
 @verify_calendar
+@measure_time()
 def delete_shared_calendar_invitation(calendar_id):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
 
         token = request.get_json(force=True).get("token")
@@ -410,14 +400,13 @@ def delete_shared_calendar_invitation(calendar_id):
                         "calendar_id": calendar_id,
                     }
                 )
-                t_1 = time.time()
 
                 return success_response(
                     message="Invitation de calendrier supprimée",
                     code="SHARED_CALENDAR_INVITATION_DELETE_SUCCESS",
                     uid=receiver_email,
                     origin="DELETE_SHARED_CALENDAR_INVITATION",
-                    log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+                    log_extra={"calendar_id": calendar_id}
                 )
     except Exception as e:
         return error_response(
@@ -432,9 +421,9 @@ def delete_shared_calendar_invitation(calendar_id):
 
 @api.route("/shared/grouped", methods=["GET"])
 @require_auth
+@measure_time()
 def handle_grouped_shared():
     try:
-        t_0 = time.time()
         uid = g.uid
 
         with get_connection() as conn:
@@ -498,14 +487,13 @@ def handle_grouped_shared():
                     if cal_id in grouped:
                         grouped[cal_id]["invitation"].append(invitation)
 
-        t_1 = time.time()
         return success_response(
             message="Données partagées groupées récupérées",
             code="SHARED_GROUPED_LOAD_SUCCESS",
             uid=uid,
             origin="SHARED_GROUPED_LOAD",
             data={"grouped": grouped},
-            log_extra={"calendar_count": len(grouped), "time": t_1 - t_0}
+            log_extra={"calendar_count": len(grouped)}
         )
 
     except Exception as e:
@@ -522,9 +510,9 @@ def handle_grouped_shared():
 @api.route("/shared/users/calendars/<calendar_id>/notifications", methods=["GET"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_shared_user_notifications(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
         
         with get_connection() as conn:
@@ -541,14 +529,14 @@ def handle_shared_user_notifications(calendar_id):
                         log_extra={"calendar_id": calendar_id}
                     )
                 notifications_enabled = calendar.get("notifications_enabled", False)
-        t_1 = time.time()
+
         return success_response(
             message="notifications récupérées",
             code="SHARED_CALENDARS_NOTIFICATIONS_SUCCESS",
             uid=uid,
             origin="SHARED_CALENDARS_NOTIFICATIONS",
             data={"notifications-enabled": notifications_enabled},
-            log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
     except Exception as e:
         return error_response(
@@ -564,9 +552,9 @@ def handle_shared_user_notifications(calendar_id):
 @api.route("/shared/users/calendars/<calendar_id>/notifications", methods=["PUT"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_shared_user_notifications_update(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         payload = request.get_json(force=True)
@@ -584,13 +572,13 @@ def handle_shared_user_notifications_update(calendar_id):
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("UPDATE shared_calendars SET notifications_enabled = %s WHERE calendar_id = %s", (notifications_enabled, calendar_id))
-        t_1 = time.time()
+
         return success_response(
             message="Notifications mises à jour",
             code="SHARED_CALENDARS_NOTIFICATIONS_SUCCESS",
             uid=uid,
             origin="SHARED_CALENDARS_NOTIFICATIONS",
-            log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+            log_extra={"calendar_id": calendar_id}
         )
     except Exception as e:
         return error_response(

--- a/backend/app/routes/shared_users.py
+++ b/backend/app/routes/shared_users.py
@@ -131,21 +131,12 @@ def handle_shared_calendars():
 # Route pour récupérer les informations d'un calendrier partagé
 @api.route("/shared/users/calendars/<calendar_id>", methods=["GET"])
 @require_auth
+@verify_calendar_share
 def handle_user_shared_calendar(calendar_id):
     try:
         t_0 = time.time()
         receiver_uid = g.uid
 
-        if not verify_calendar_share(calendar_id, receiver_uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="SHARED_CALENDARS_LOAD_ERROR",
-                status_code=403,
-                uid=receiver_uid,
-                origin="SHARED_CALENDARS_LOAD",
-                log_extra={"calendar_id": calendar_id}
-            )
-        
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute(SELECT_SHARED_CALENDAR, (calendar_id,))
@@ -197,23 +188,13 @@ def handle_user_shared_calendar(calendar_id):
             log_extra={"calendar_id": calendar_id}
         )
 
-# Route pour générer un calendrier partagé
 @api.route("/shared/users/calendars/<calendar_id>/schedule", methods=["GET"])
 @require_auth
+@verify_calendar_share
 def handle_user_shared_calendar_schedule(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-
-        if not verify_calendar_share(calendar_id, uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="SHARED_CALENDARS_LOAD_ERROR",
-                status_code=403,
-                uid=uid,
-                origin="SHARED_CALENDARS_LOAD",
-                log_extra={"calendar_id": calendar_id}
-            )
 
         start_date = request.args.get("startTime")
         if not start_date:
@@ -251,21 +232,11 @@ def handle_user_shared_calendar_schedule(calendar_id):
 # Route pour supprimer un calendrier partagé pour le receiver
 @api.route("/shared/users/calendars/<calendar_id>", methods=["DELETE"])
 @require_auth
+@verify_calendar_share
 def handle_delete_user_shared_calendar(calendar_id):
     try:
         t_0 = time.time()
         receiver_uid = g.uid
-
-        if not verify_calendar_share(calendar_id, receiver_uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS, 
-                code="SHARED_CALENDARS_DELETE_ERROR", 
-                status_code=403, 
-                uid=receiver_uid, 
-                origin="SHARED_CALENDARS_DELETE",
-                log_extra={"calendar_id": calendar_id}
-            )
-        
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -319,6 +290,7 @@ def handle_delete_user_shared_calendar(calendar_id):
 # Route pour supprimer un utilisateur partagé pour le owner
 @api.route("/shared/users/<calendar_id>/<receiver_uid>", methods=["DELETE"])
 @require_auth
+@verify_calendar
 def handle_delete_user_shared_user(calendar_id, receiver_uid):
     try:
         t_0 = time.time()
@@ -404,20 +376,11 @@ def handle_delete_user_shared_user(calendar_id, receiver_uid):
 # fonction pour supprimer une invitation de calendrier partagé pour un user sans compte
 @api.route("/invitations/<calendar_id>", methods=["DELETE"])
 @require_auth
+@verify_calendar
 def delete_shared_calendar_invitation(calendar_id):
     try:
         t_0 = time.time()
         owner_uid = g.uid
-
-        if not verify_calendar(calendar_id, owner_uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="UNAUTHORIZED_ACCESS",
-                status_code=404,
-                uid=owner_uid,
-                origin="GET_MEDICINE_BOXES",
-                log_extra={"calendar_id": calendar_id}
-            )
 
         token = request.get_json(force=True).get("token")
         receiver_email = request.get_json(force=True).get("email")
@@ -557,19 +520,11 @@ def handle_grouped_shared():
 
 @api.route("/shared/users/calendars/<calendar_id>/notifications", methods=["GET"])
 @require_auth
+@verify_calendar_share
 def handle_shared_user_notifications(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        if not verify_calendar_share(calendar_id, uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="SHARED_CALENDARS_NOTIFICATIONS_ERROR",
-                status_code=403,
-                uid=uid,
-                origin="SHARED_CALENDARS_NOTIFICATIONS",
-                log_extra={"calendar_id": calendar_id}
-            )
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("SELECT notifications_enabled FROM shared_calendars WHERE calendar_id = %s", (calendar_id,))
@@ -606,19 +561,11 @@ def handle_shared_user_notifications(calendar_id):
 
 @api.route("/shared/users/calendars/<calendar_id>/notifications", methods=["PUT"])
 @require_auth
+@verify_calendar_share
 def handle_shared_user_notifications_update(calendar_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        if not verify_calendar_share(calendar_id, uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS,
-                code="SHARED_CALENDARS_NOTIFICATIONS_ERROR",
-                status_code=403,
-                uid=uid,
-                origin="SHARED_CALENDARS_NOTIFICATIONS",
-                log_extra={"calendar_id": calendar_id}
-            )
         data = request.get_json()
         if not data or "notifications-enabled" not in data:
             return warning_response(

--- a/backend/app/routes/shared_users.py
+++ b/backend/app/routes/shared_users.py
@@ -23,8 +23,8 @@ SELECT_SHARED_CALENDAR = "SELECT * FROM calendars WHERE id = %s"
 
 # Route pour récupérer les calendriers partagés
 @api.route("/shared/users/calendars", methods=["GET"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_shared_calendars():
     try:
         uid = g.uid
@@ -125,9 +125,9 @@ def handle_shared_calendars():
 
 # Route pour récupérer les informations d'un calendrier partagé
 @api.route("/shared/users/calendars/<calendar_id>", methods=["GET"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_user_shared_calendar(calendar_id):
     try:
         uid = g.uid
@@ -183,9 +183,9 @@ def handle_user_shared_calendar(calendar_id):
         )
 
 @api.route("/shared/users/calendars/<calendar_id>/schedule", methods=["GET"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_user_shared_calendar_schedule(calendar_id):
     try:
         uid = g.uid
@@ -224,9 +224,9 @@ def handle_user_shared_calendar_schedule(calendar_id):
 
 # Route pour supprimer un calendrier partagé pour le receiver
 @api.route("/shared/users/calendars/<calendar_id>", methods=["DELETE"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_delete_user_shared_calendar(calendar_id):
     try:
         receiver_uid = g.uid
@@ -281,9 +281,9 @@ def handle_delete_user_shared_calendar(calendar_id):
 
 # Route pour supprimer un utilisateur partagé pour le owner
 @api.route("/shared/users/<calendar_id>/<receiver_uid>", methods=["DELETE"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_delete_user_shared_user(calendar_id, receiver_uid):
     try:
         owner_uid = g.uid
@@ -366,9 +366,9 @@ def handle_delete_user_shared_user(calendar_id, receiver_uid):
 
 # fonction pour supprimer une invitation de calendrier partagé pour un user sans compte
 @api.route("/invitations/<calendar_id>", methods=["DELETE"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def delete_shared_calendar_invitation(calendar_id):
     try:
         owner_uid = g.uid
@@ -420,8 +420,8 @@ def delete_shared_calendar_invitation(calendar_id):
 
 
 @api.route("/shared/grouped", methods=["GET"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_grouped_shared():
     try:
         uid = g.uid
@@ -508,9 +508,9 @@ def handle_grouped_shared():
 
 
 @api.route("/shared/users/calendars/<calendar_id>/notifications", methods=["GET"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_shared_user_notifications(calendar_id):
     try:
         uid = g.uid
@@ -550,9 +550,9 @@ def handle_shared_user_notifications(calendar_id):
         )
 
 @api.route("/shared/users/calendars/<calendar_id>/notifications", methods=["PUT"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_shared_user_notifications_update(calendar_id):
     try:
         uid = g.uid

--- a/backend/app/routes/shared_users_medicines.py
+++ b/backend/app/routes/shared_users_medicines.py
@@ -49,9 +49,11 @@ def handle_update_shared_box(calendar_id, box_id):
     try:
         t_0 = time.time()
         uid = g.uid
-        data = request.get_json()
 
-        if not data:
+        payload = request.get_json(force=True)
+        box = payload.get("box")
+
+        if not box:
             return warning_response(
                 message="champs requis manquants",
                 code="MISSING_REQUIRED_FIELDS",
@@ -61,7 +63,7 @@ def handle_update_shared_box(calendar_id, box_id):
                 log_extra={"calendar_id": calendar_id, "box_id": box_id}
             )
 
-        update_box(box_id, calendar_id, data)
+        update_box(box_id, calendar_id, box)
 
         t_1 = time.time()
         return success_response(
@@ -92,9 +94,10 @@ def handle_create_shared_box(calendar_id):
         t_0 = time.time()
         uid = g.uid
 
-        data = request.get_json()
+        payload = request.get_json(force=True)
+        box = payload.get("box")
 
-        if not data:
+        if not box:
             return warning_response(
                 message="champs requis manquants",
                 code="MISSING_REQUIRED_FIELDS",
@@ -104,7 +107,7 @@ def handle_create_shared_box(calendar_id):
                 log_extra={"calendar_id": calendar_id}
             )
 
-        box_id = create_box(calendar_id, data)
+        box_id = create_box(calendar_id, box)
         t_1 = time.time()
 
         return success_response(
@@ -166,7 +169,9 @@ def handle_use_shared_users_pillulier(calendar_id):
         t_0 = time.time()
         uid = g.uid
 
-        start_date = request.args.get("startTime")
+        payload = request.get_json(force=True)
+        start_date = payload.get("startDate")
+
         if not start_date:
             start_date = datetime.now(timezone.utc).date()
         else:

--- a/backend/app/routes/shared_users_medicines.py
+++ b/backend/app/routes/shared_users_medicines.py
@@ -8,25 +8,14 @@ import time
 from app.services.medication import use_pillulier
 from datetime import datetime, timezone
 
-ERROR_CALENDAR_NOT_FOUND = "calendrier non trouvé"
-
 # Route pour récupérer les boites de médicaments d'un calendrier
 @api.route("/shared/users/calendars/<calendar_id>/boxes", methods=["GET"])
 @require_auth
+@verify_calendar_share
 def handle_shared_boxes(calendar_id):
     try:
         t_0 = time.time()
         receiver_uid = g.uid
-
-        if not verify_calendar_share(calendar_id, receiver_uid):
-            return warning_response(
-                message=ERROR_CALENDAR_NOT_FOUND,
-                code="SHARED_USER_CALENDAR_BOXES_LOAD_ERROR",
-                status_code=404,
-                uid=receiver_uid,
-                origin="SHARED_USER_CALENDAR_BOXES_LOAD",
-                log_extra={"calendar_id": calendar_id}
-            )
 
         boxes = get_boxes(calendar_id)
         t_1 = time.time()
@@ -55,13 +44,14 @@ def handle_shared_boxes(calendar_id):
 # Route pour modifier une boite de médicaments
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>", methods=["PUT"])
 @require_auth
+@verify_calendar_share
 def handle_update_shared_box(calendar_id, box_id):
     try:
         t_0 = time.time()
         uid = g.uid
         data = request.get_json()
 
-        if not data or not verify_calendar_share(calendar_id, uid):
+        if not data:
             return warning_response(
                 message="champs requis manquants",
                 code="MISSING_REQUIRED_FIELDS",
@@ -96,6 +86,7 @@ def handle_update_shared_box(calendar_id, box_id):
 # Route pour créer une boite de médicaments
 @api.route("/shared/users/calendars/<calendar_id>/boxes", methods=["POST"])
 @require_auth
+@verify_calendar_share
 def handle_create_shared_box(calendar_id):
     try:
         t_0 = time.time()
@@ -103,7 +94,7 @@ def handle_create_shared_box(calendar_id):
 
         data = request.get_json()
 
-        if not data or not verify_calendar_share(calendar_id, uid):
+        if not data:
             return warning_response(
                 message="champs requis manquants",
                 code="MISSING_REQUIRED_FIELDS",
@@ -139,6 +130,7 @@ def handle_create_shared_box(calendar_id):
 # Route pour supprimer une boite de médicaments
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>", methods=["DELETE"])
 @require_auth
+@verify_calendar_share
 def handle_delete_shared_box(calendar_id, box_id):
     try:
         t_0 = time.time()
@@ -166,10 +158,11 @@ def handle_delete_shared_box(calendar_id, box_id):
             log_extra={"calendar_id": calendar_id, "box_id": box_id}
         )
 
-@api.route("/shared/users/calendars/<calendarId>/pilluliers/used", methods=["POST"])
+@api.route("/shared/users/calendars/<calendar_id>/pilluliers/used", methods=["POST"])
 @require_auth
-def handle_use_shared_users_pillulier(calendarId):
-    try:   
+@verify_calendar_share
+def handle_use_shared_users_pillulier(calendar_id):
+    try:
         t_0 = time.time()
         uid = g.uid
 
@@ -179,18 +172,7 @@ def handle_use_shared_users_pillulier(calendarId):
         else:
             start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
 
-
-        if not verify_calendar_share(calendarId, uid):
-            return warning_response(
-                message="calendrier non trouvé",
-                code="SHARED_USER_CALENDAR_NOT_FOUND",
-                status_code=404,
-                uid=uid,
-                origin="SHARED_USER_USE_PILLULIER",
-                log_extra={"calendar_id": calendarId}
-            )
-        
-        result = use_pillulier(calendarId, start_date)
+        result = use_pillulier(calendar_id, start_date)
         if not result:
             return warning_response(
                 message="erreur lors de l'utilisation du pilulier",
@@ -198,7 +180,7 @@ def handle_use_shared_users_pillulier(calendarId):
                 status_code=500,
                 uid=uid,
                 origin="SHARED_USER_USE_PILLULIER",
-                log_extra={"calendar_id": calendarId}
+                log_extra={"calendar_id": calendar_id}
             )
         t_1 = time.time()
         return success_response(
@@ -206,9 +188,9 @@ def handle_use_shared_users_pillulier(calendarId):
             code="PILLULIER_USED",
             uid=uid,
             origin="SHARED_USER_USE_PILLULIER",
-            log_extra={"time": t_1 - t_0, "calendar_id": calendarId}
+            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id}
         )
-    except Exception as e:  
+    except Exception as e:
         return error_response(
             message="erreur lors de l'utilisation du pilulier",
             code="USE_PILLULIER_ERROR",
@@ -216,27 +198,18 @@ def handle_use_shared_users_pillulier(calendarId):
             uid=uid,
             origin="SHARED_USER_USE_PILLULIER",
             error=str(e),
-            log_extra={"calendar_id": calendarId}
+            log_extra={"calendar_id": calendar_id}
         )
         
 
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>/restock", methods=["POST"])
 @require_auth
+@verify_calendar_share
 def handle_shared_user_restock_box(calendar_id, box_id):
     try:
         uid = g.uid
         t_0 = time.time()
 
-        if not verify_calendar_share(calendar_id, uid):
-            return warning_response(
-                message="calendrier non trouvé",
-                code="SHARED_USER_CALENDAR_NOT_FOUND",
-                status_code=404,
-                uid=uid,
-                origin="RESTOCK_MEDICINE_BOX",
-                log_extra={"calendar_id": calendar_id, "box_id": box_id}
-            )
-        
         if not restock_box(box_id, calendar_id):
             return warning_response(
                 message="boite de médicaments non trouvée",

--- a/backend/app/routes/shared_users_medicines.py
+++ b/backend/app/routes/shared_users_medicines.py
@@ -4,9 +4,9 @@ from . import api
 from app.utils.responses import success_response, error_response, warning_response
 from app.services.calendar import verify_calendar_share
 from app.services.medication import get_boxes, update_box, create_box, delete_box, restock_box
-import time
 from app.services.medication import use_pillulier
 from datetime import datetime, timezone
+from app.utils.measure import measure_time
 
 # Route pour récupérer les boites de médicaments d'un calendrier
 @api.route("/shared/users/calendars/<calendar_id>/boxes", methods=["GET"])
@@ -14,19 +14,17 @@ from datetime import datetime, timezone
 @verify_calendar_share
 def handle_shared_boxes(calendar_id):
     try:
-        t_0 = time.time()
-        receiver_uid = g.uid
+        uid = g.uid
 
         boxes = get_boxes(calendar_id)
-        t_1 = time.time()
 
         return success_response(
             message="boites de médicaments récupérées",
             code="MEDICINE_BOXES_FETCHED",
-            uid=receiver_uid,
+            uid=uid,
             origin="GET_MEDICINE_BOXES",
             data={"boxes": boxes},
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id, "boxes_count": len(boxes)}
+            log_extra={"calendar_id": calendar_id, "boxes_count": len(boxes)}
         )
 
     except Exception as e:
@@ -34,7 +32,7 @@ def handle_shared_boxes(calendar_id):
             message="erreur lors de la récupération des boites de médicaments",
             code="GET_MEDICINE_BOXES_ERROR",
             status_code=500,
-            uid=receiver_uid,
+            uid=uid,
             origin="GET_MEDICINE_BOXES",
             error=str(e),
             log_extra={"calendar_id": calendar_id}
@@ -45,9 +43,9 @@ def handle_shared_boxes(calendar_id):
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>", methods=["PUT"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_update_shared_box(calendar_id, box_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         payload = request.get_json(force=True)
@@ -65,13 +63,12 @@ def handle_update_shared_box(calendar_id, box_id):
 
         update_box(box_id, calendar_id, box)
 
-        t_1 = time.time()
         return success_response(
             message="boite de médicaments modifiée",
             code="MEDICINE_BOX_UPDATED",
             uid=uid,
             origin="UPDATE_MEDICINE_BOX",
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id, "box_id": box_id}
+            log_extra={"calendar_id": calendar_id, "box_id": box_id}
         )
 
     except Exception as e:
@@ -89,9 +86,9 @@ def handle_update_shared_box(calendar_id, box_id):
 @api.route("/shared/users/calendars/<calendar_id>/boxes", methods=["POST"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_create_shared_box(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         payload = request.get_json(force=True)
@@ -108,7 +105,6 @@ def handle_create_shared_box(calendar_id):
             )
 
         box_id = create_box(calendar_id, box)
-        t_1 = time.time()
 
         return success_response(
             message="boite de médicaments créée",
@@ -116,7 +112,7 @@ def handle_create_shared_box(calendar_id):
             uid=uid,
             origin="CREATE_MEDICINE_BOX",
             data={"box_id": box_id},
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id}
+            log_extra={"calendar_id": calendar_id}
         )
 
     except Exception as e:
@@ -134,20 +130,19 @@ def handle_create_shared_box(calendar_id):
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>", methods=["DELETE"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_delete_shared_box(calendar_id, box_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         delete_box(box_id, calendar_id)
-        t_1 = time.time()
 
         return success_response(
             message="boite de médicaments supprimée",
             code="MEDICINE_BOX_DELETED",
             uid=uid,
             origin="DELETE_MEDICINE_BOX",
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id, "box_id": box_id}
+            log_extra={"calendar_id": calendar_id, "box_id": box_id}
         )
 
     except Exception as e:
@@ -164,9 +159,9 @@ def handle_delete_shared_box(calendar_id, box_id):
 @api.route("/shared/users/calendars/<calendar_id>/pilluliers/used", methods=["POST"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_use_shared_users_pillulier(calendar_id):
     try:
-        t_0 = time.time()
         uid = g.uid
 
         payload = request.get_json(force=True)
@@ -187,13 +182,12 @@ def handle_use_shared_users_pillulier(calendar_id):
                 origin="SHARED_USER_USE_PILLULIER",
                 log_extra={"calendar_id": calendar_id}
             )
-        t_1 = time.time()
         return success_response(
             message="pilulier utilisé avec succès",
             code="PILLULIER_USED",
             uid=uid,
             origin="SHARED_USER_USE_PILLULIER",
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id}
+            log_extra={"calendar_id": calendar_id}
         )
     except Exception as e:
         return error_response(
@@ -210,10 +204,10 @@ def handle_use_shared_users_pillulier(calendar_id):
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>/restock", methods=["POST"])
 @require_auth
 @verify_calendar_share
+@measure_time()
 def handle_shared_user_restock_box(calendar_id, box_id):
     try:
         uid = g.uid
-        t_0 = time.time()
 
         if not restock_box(box_id, calendar_id):
             return warning_response(
@@ -224,14 +218,14 @@ def handle_shared_user_restock_box(calendar_id, box_id):
                 origin="RESTOCK_MEDICINE_BOX",
                 log_extra={"calendar_id": calendar_id, "box_id": box_id}
             )
-        t_1 = time.time()
+
         return success_response(
             message="boite de médicaments réapprovisionnée",
             code="MEDICINE_BOX_RESTOCKED",
             uid=uid,
             origin="RESTOCK_MEDICINE_BOX",
             data={"box_id": box_id},
-            log_extra={"time": t_1 - t_0, "calendar_id": calendar_id, "box_id": box_id}
+            log_extra={"calendar_id": calendar_id, "box_id": box_id}
         )
     except Exception as e:
         return error_response(

--- a/backend/app/routes/shared_users_medicines.py
+++ b/backend/app/routes/shared_users_medicines.py
@@ -10,6 +10,7 @@ from app.utils.measure import measure_time
 
 # Route pour récupérer les boites de médicaments d'un calendrier
 @api.route("/shared/users/calendars/<calendar_id>/boxes", methods=["GET"])
+@measure_time()
 @require_auth
 @verify_calendar_share
 def handle_shared_boxes(calendar_id):
@@ -41,9 +42,9 @@ def handle_shared_boxes(calendar_id):
 
 # Route pour modifier une boite de médicaments
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>", methods=["PUT"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_update_shared_box(calendar_id, box_id):
     try:
         uid = g.uid
@@ -84,9 +85,9 @@ def handle_update_shared_box(calendar_id, box_id):
 
 # Route pour créer une boite de médicaments
 @api.route("/shared/users/calendars/<calendar_id>/boxes", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_create_shared_box(calendar_id):
     try:
         uid = g.uid
@@ -128,9 +129,9 @@ def handle_create_shared_box(calendar_id):
 
 # Route pour supprimer une boite de médicaments
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>", methods=["DELETE"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_delete_shared_box(calendar_id, box_id):
     try:
         uid = g.uid
@@ -157,9 +158,9 @@ def handle_delete_shared_box(calendar_id, box_id):
         )
 
 @api.route("/shared/users/calendars/<calendar_id>/pilluliers/used", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_use_shared_users_pillulier(calendar_id):
     try:
         uid = g.uid
@@ -202,9 +203,9 @@ def handle_use_shared_users_pillulier(calendar_id):
         
 
 @api.route("/shared/users/calendars/<calendar_id>/boxes/<box_id>/restock", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar_share
-@measure_time()
 def handle_shared_user_restock_box(calendar_id, box_id):
     try:
         uid = g.uid

--- a/backend/app/routes/tokens.py
+++ b/backend/app/routes/tokens.py
@@ -14,23 +14,22 @@ from app.services.calendar import verify_calendar, verify_token_owner, verify_to
 def handle_tokens():
     try:
         t_0 = time.time()
-        if request.method == "GET":
-            uid = g.uid
+        uid = g.uid
 
-            with get_connection() as conn:
-                with conn.cursor() as cursor:
-                    cursor.execute("SELECT * FROM shared_tokens WHERE owner_uid = %s", (uid,))
-                    tokens_list = cursor.fetchall()
-                    t_1 = time.time()
+        with get_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT * FROM shared_tokens WHERE owner_uid = %s", (uid,))
+                tokens_list = cursor.fetchall()
+        t_1 = time.time()
 
-            return success_response(
-                message="tokens récupérés", 
-                code="TOKENS_FETCH", 
-                uid=uid, 
-                origin="TOKENS_FETCH", 
-                data={"tokens": tokens_list},
-                log_extra={"time": t_1 - t_0}
-            )
+        return success_response(
+            message="tokens récupérés", 
+            code="TOKENS_FETCH", 
+            uid=uid, 
+            origin="TOKENS_FETCH", 
+            data={"tokens": tokens_list},
+            log_extra={"time": t_1 - t_0}
+        )
         
     except Exception as e:
         return error_response(
@@ -52,14 +51,14 @@ def handle_create_token(calendar_id):
         t_0 = time.time()
         owner_uid = g.uid
 
-        data = request.get_json(force=True)
+        payload = request.get_json(force=True)
 
-        expires_at = data.get("expiresAt")
+        expires_at = payload.get("expiresAt")
         if not expires_at:
             expires_at = None
-            
-        permissions = data.get("permissions")
-        
+
+        permissions = payload.get("permissions")
+
         if not permissions:
             permissions = ["read"]
 
@@ -156,8 +155,9 @@ def handle_update_token_expiration(token):
         t_0 = time.time()
         owner_uid = g.uid
 
-        data = request.get_json(force=True)
-        expires_at = data.get("expiresAt")
+        payload = request.get_json(force=True)
+        expires_at = payload.get("expiresAt")
+
         if not expires_at:
             expires_at = None
 
@@ -199,9 +199,9 @@ def handle_update_token_permissions(token):
         t_0 = time.time()
         owner_uid = g.uid
 
-        data = request.get_json(force=True)
+        payload = request.get_json(force=True)
 
-        permissions = data.get("permissions")
+        permissions = payload.get("permissions")
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -237,7 +237,8 @@ def handle_generate_token_schedule(token):
     try:
         t_0 = time.time()
 
-        start_date = request.args.get("startTime")
+        start_date = request.args.get("startDate")
+
         if not start_date:
             start_date = datetime.now(timezone.utc).date()
         else:
@@ -275,10 +276,11 @@ def handle_generate_token_schedule(token):
 def handle_get_token_metadata(token):
     try:
         t_0 = time.time()
+        calendar_id = g.calendar_id
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
-                cursor.execute("SELECT * FROM shared_tokens WHERE id = %s", (token,))
+                cursor.execute("SELECT owner_uid FROM shared_tokens WHERE id = %s", (token,))
                 token_data = cursor.fetchone()
                 if not token_data:
                     return warning_response(
@@ -290,7 +292,6 @@ def handle_get_token_metadata(token):
                         log_extra={"token": token}
                     )
 
-                calendar_id = token_data.get("calendar_id")
                 owner_uid = token_data.get("owner_uid")
 
                 t_1 = time.time()

--- a/backend/app/routes/tokens.py
+++ b/backend/app/routes/tokens.py
@@ -10,8 +10,8 @@ from app.utils.measure import measure_time
 
 # Route pour récupérer tous les tokens et les informations associées
 @api.route("/tokens", methods=["GET"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_tokens():
     try:
         uid = g.uid
@@ -42,9 +42,9 @@ def handle_tokens():
 
 # Route pour créer un lien de partage avec un token
 @api.route("/tokens/<calendar_id>", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_calendar
-@measure_time()
 def handle_create_token(calendar_id):
     try:
         owner_uid = g.uid
@@ -106,9 +106,9 @@ def handle_create_token(calendar_id):
 
 # Route pour révoquer un token
 @api.route("/tokens/revoke/<token>", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_token_owner
-@measure_time()
 def handle_update_revoke_token(token):
     try:
         owner_uid = g.uid
@@ -143,9 +143,9 @@ def handle_update_revoke_token(token):
 
 # Route pour mettre à jour l'expiration d'un token
 @api.route("/tokens/expiration/<token>", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_token_owner
-@measure_time()
 def handle_update_token_expiration(token):
     try:
         owner_uid = g.uid
@@ -185,9 +185,9 @@ def handle_update_token_expiration(token):
 
 # Route pour mettre à jour les permissions d'un token
 @api.route("/tokens/permissions/<token>", methods=["POST"])
+@measure_time()
 @require_auth
 @verify_token_owner
-@measure_time()
 def handle_update_token_permissions(token):
     try:
         owner_uid = g.uid
@@ -222,8 +222,8 @@ def handle_update_token_permissions(token):
 
 # Route pour générer un calendrier partagé pour un token
 @api.route("/tokens/<token>/schedule", methods=["GET"])
-@verify_token
 @measure_time()
+@verify_token
 def handle_generate_token_schedule(token):
     try:
         start_date = request.args.get("startDate")
@@ -258,8 +258,8 @@ def handle_generate_token_schedule(token):
 
 # Route pour obtenir les métadonnées d’un token public
 @api.route("/tokens/<token>", methods=["GET"])
-@verify_token
 @measure_time()
+@verify_token
 def handle_get_token_metadata(token):
     try:
         calendar_id = g.calendar_id
@@ -302,9 +302,9 @@ def handle_get_token_metadata(token):
 
 # Route pour supprimer un token
 @api.route("/tokens/<token>", methods=["DELETE"])
+@measure_time()
 @require_auth
 @verify_token_owner
-@measure_time()
 def handle_delete_token(token):
     try:
         owner_uid = g.uid

--- a/backend/app/routes/tokens.py
+++ b/backend/app/routes/tokens.py
@@ -8,8 +8,6 @@ from app.db.connection import get_connection
 from app.services.calendar import generate_calendar_schedule
 from app.services.calendar import verify_calendar, verify_token_owner, verify_token
 
-ERROR_UNAUTHORIZED_ACCESS = "accès refusé"
-
 # Route pour récupérer tous les tokens et les informations associées
 @api.route("/tokens", methods=["GET"])
 @require_auth
@@ -48,6 +46,7 @@ def handle_tokens():
 # Route pour créer un lien de partage avec un token
 @api.route("/tokens/<calendar_id>", methods=["POST"])
 @require_auth
+@verify_calendar
 def handle_create_token(calendar_id):
     try:
         t_0 = time.time()
@@ -63,8 +62,6 @@ def handle_create_token(calendar_id):
         
         if not permissions:
             permissions = ["read"]
-
-        verify_calendar(calendar_id, owner_uid)
 
 
         # Verifier si le calendrier est déjà partagé
@@ -114,20 +111,11 @@ def handle_create_token(calendar_id):
 # Route pour révoquer un token
 @api.route("/tokens/revoke/<token>", methods=["POST"])
 @require_auth
+@verify_token_owner
 def handle_update_revoke_token(token):
     try:
         t_0 = time.time()
         owner_uid = g.uid
-
-        if not verify_token_owner(token, owner_uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS, 
-                code="TOKEN_NOT_AUTHORIZED", 
-                status_code=403, 
-                uid=owner_uid, 
-                origin="TOKEN_REVOKE", 
-                log_extra={"token": token}
-            )
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -162,6 +150,7 @@ def handle_update_revoke_token(token):
 # Route pour mettre à jour l'expiration d'un token
 @api.route("/tokens/expiration/<token>", methods=["POST"])
 @require_auth
+@verify_token_owner
 def handle_update_token_expiration(token):
     try:
         t_0 = time.time()
@@ -175,16 +164,6 @@ def handle_update_token_expiration(token):
         if expires_at:
             expires_at = datetime.strptime(expires_at, "%Y-%m-%d").date()
 
-        if not verify_token_owner(token, owner_uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS, 
-                code="TOKEN_NOT_AUTHORIZED", 
-                status_code=403, 
-                uid=owner_uid, 
-                origin="TOKEN_EXPIRATION_UPDATE", 
-                log_extra={"token": token}
-            )
-        
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("UPDATE shared_tokens SET expires_at = %s WHERE id = %s AND owner_uid = %s", (expires_at, token, owner_uid))
@@ -214,6 +193,7 @@ def handle_update_token_expiration(token):
 # Route pour mettre à jour les permissions d'un token
 @api.route("/tokens/permissions/<token>", methods=["POST"])
 @require_auth
+@verify_token_owner
 def handle_update_token_permissions(token):
     try:
         t_0 = time.time()
@@ -221,16 +201,6 @@ def handle_update_token_permissions(token):
 
         data = request.get_json(force=True)
 
-        if not verify_token_owner(token, owner_uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS, 
-                code="TOKEN_NOT_AUTHORIZED", 
-                status_code=403, 
-                uid=owner_uid, 
-                origin="TOKEN_PERMISSIONS_UPDATE", 
-                log_extra={"token": token}
-            )
-        
         permissions = data.get("permissions")
 
         with get_connection() as conn:
@@ -262,6 +232,7 @@ def handle_update_token_permissions(token):
 # Route pour générer un calendrier partagé pour un token
 @api.route("/tokens/<token>/schedule", methods=["GET"])
 @require_auth
+@verify_token
 def handle_generate_token_schedule(token):
     try:
         t_0 = time.time()
@@ -272,16 +243,7 @@ def handle_generate_token_schedule(token):
         else:
             start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
 
-        calendar_id = verify_token(token)
-        if not calendar_id:
-            return warning_response(
-                message="token invalide", 
-                code="TOKEN_INVALID", 
-                status_code=404, 
-                uid="unknown", 
-                origin="TOKEN_GENERATE_SCHEDULE", 
-                log_extra={"token": token}
-            )
+        calendar_id = g.calendar_id
 
         schedule, table, calendar_name = generate_calendar_schedule(calendar_id, start_date)
         
@@ -309,18 +271,10 @@ def handle_generate_token_schedule(token):
 # Route pour obtenir les métadonnées d’un token public
 @api.route("/tokens/<token>", methods=["GET"])
 @require_auth
+@verify_token
 def handle_get_token_metadata(token):
     try:
         t_0 = time.time()
-        if not verify_token(token):
-            return warning_response(
-                message="token invalide",
-                code="TOKEN_INVALID",
-                status_code=404,
-                uid="unknown",
-                origin="TOKEN_METADATA_LOAD",
-                log_extra={"token": token}
-            )
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -365,20 +319,11 @@ def handle_get_token_metadata(token):
 # Route pour supprimer un token
 @api.route("/tokens/<token>", methods=["DELETE"])
 @require_auth
+@verify_token_owner
 def handle_delete_token(token):
     try:
         t_0 = time.time()
         owner_uid = g.uid
-
-        if not verify_token_owner(token, owner_uid):
-            return warning_response(
-                message=ERROR_UNAUTHORIZED_ACCESS, 
-                code="TOKEN_NOT_AUTHORIZED", 
-                status_code=403, 
-                uid=owner_uid, 
-                origin="TOKEN_DELETE", 
-                log_extra={"token": token}
-            )
 
         with get_connection() as conn:
             with conn.cursor() as cursor:

--- a/backend/app/routes/tokens.py
+++ b/backend/app/routes/tokens.py
@@ -2,33 +2,31 @@ from app.utils.responses import success_response, error_response, warning_respon
 from app.utils.auth import require_auth
 from datetime import datetime, timezone
 from . import api
-import time
 from flask import request, g
 from app.db.connection import get_connection
 from app.services.calendar import generate_calendar_schedule
 from app.services.calendar import verify_calendar, verify_token_owner, verify_token
+from app.utils.measure import measure_time
 
 # Route pour récupérer tous les tokens et les informations associées
 @api.route("/tokens", methods=["GET"])
 @require_auth
+@measure_time()
 def handle_tokens():
     try:
-        t_0 = time.time()
         uid = g.uid
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("SELECT * FROM shared_tokens WHERE owner_uid = %s", (uid,))
                 tokens_list = cursor.fetchall()
-        t_1 = time.time()
 
         return success_response(
             message="tokens récupérés", 
             code="TOKENS_FETCH", 
             uid=uid, 
             origin="TOKENS_FETCH", 
-            data={"tokens": tokens_list},
-            log_extra={"time": t_1 - t_0}
+            data={"tokens": tokens_list}
         )
         
     except Exception as e:
@@ -46,9 +44,9 @@ def handle_tokens():
 @api.route("/tokens/<calendar_id>", methods=["POST"])
 @require_auth
 @verify_calendar
+@measure_time()
 def handle_create_token(calendar_id):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
 
         payload = request.get_json(force=True)
@@ -85,14 +83,13 @@ def handle_create_token(calendar_id):
                     """,
                     (calendar_id, expires_at, permissions, False, owner_uid)
                 )
-                t_1 = time.time()
 
                 return success_response(
                     message="token créé", 
                     code="TOKEN_CREATED", 
                     uid=owner_uid, 
                     origin="TOKEN_CREATE",
-                    log_extra={"calendar_id": calendar_id, "time": t_1 - t_0}
+                    log_extra={"calendar_id": calendar_id}
                 )
 
     except Exception as e:
@@ -111,9 +108,9 @@ def handle_create_token(calendar_id):
 @api.route("/tokens/revoke/<token>", methods=["POST"])
 @require_auth
 @verify_token_owner
+@measure_time()
 def handle_update_revoke_token(token):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
 
         with get_connection() as conn:
@@ -124,14 +121,12 @@ def handle_update_revoke_token(token):
                 revoked = cursor.fetchone()
                 revoked = revoked.get("revoked")
 
-                t_1 = time.time()
-
                 return success_response(
                     message="token révoqué" if revoked else "token réactivé", 
                     code="TOKEN_REVOKE_SUCCESS" if revoked else "TOKEN_REACTIVATED_SUCCESS", 
                     uid=owner_uid, 
                     origin="TOKEN_REVOKE", 
-                    log_extra={"token": token, "time": t_1 - t_0}
+                    log_extra={"token": token}
                 )
 
     except Exception as e:
@@ -150,9 +145,9 @@ def handle_update_revoke_token(token):
 @api.route("/tokens/expiration/<token>", methods=["POST"])
 @require_auth
 @verify_token_owner
+@measure_time()
 def handle_update_token_expiration(token):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
 
         payload = request.get_json(force=True)
@@ -168,14 +163,12 @@ def handle_update_token_expiration(token):
             with conn.cursor() as cursor:
                 cursor.execute("UPDATE shared_tokens SET expires_at = %s WHERE id = %s AND owner_uid = %s", (expires_at, token, owner_uid))
 
-                t_1 = time.time()
-
                 return success_response(
                     message="expiration du token mise à jour", 
                     code="TOKEN_EXPIRATION_UPDATED", 
                     uid=owner_uid, 
                     origin="TOKEN_EXPIRATION_UPDATE", 
-                    log_extra={"token": token, "time": t_1 - t_0}
+                    log_extra={"token": token}
                 )
 
     except Exception as e:
@@ -194,9 +187,9 @@ def handle_update_token_expiration(token):
 @api.route("/tokens/permissions/<token>", methods=["POST"])
 @require_auth
 @verify_token_owner
+@measure_time()
 def handle_update_token_permissions(token):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
 
         payload = request.get_json(force=True)
@@ -207,14 +200,12 @@ def handle_update_token_permissions(token):
             with conn.cursor() as cursor:
                 cursor.execute("UPDATE shared_tokens SET permissions = %s WHERE id = %s AND owner_uid = %s", (permissions, token, owner_uid))
 
-                t_1 = time.time()
-
                 return success_response(
                     message="permissions du token mises à jour", 
                     code="TOKEN_PERMISSIONS_UPDATED", 
                     uid=owner_uid, 
                     origin="TOKEN_PERMISSIONS_UPDATE", 
-                    log_extra={"token": token, "time": t_1 - t_0}
+                    log_extra={"token": token}
                 )
 
     except Exception as e:
@@ -231,12 +222,10 @@ def handle_update_token_permissions(token):
 
 # Route pour générer un calendrier partagé pour un token
 @api.route("/tokens/<token>/schedule", methods=["GET"])
-@require_auth
 @verify_token
+@measure_time()
 def handle_generate_token_schedule(token):
     try:
-        t_0 = time.time()
-
         start_date = request.args.get("startDate")
 
         if not start_date:
@@ -247,8 +236,6 @@ def handle_generate_token_schedule(token):
         calendar_id = g.calendar_id
 
         schedule, table, calendar_name = generate_calendar_schedule(calendar_id, start_date)
-        
-        t_1 = time.time()
 
         return success_response(
             message="calendrier généré", 
@@ -256,7 +243,7 @@ def handle_generate_token_schedule(token):
             uid="unknown", 
             origin="TOKEN_GENERATE_SCHEDULE", 
             data={"schedule": schedule, "table": table, "calendar_name": calendar_name},
-            log_extra={"token": token, "time": t_1 - t_0}
+            log_extra={"token": token}
         )
     except Exception as e:
         return error_response(
@@ -271,11 +258,10 @@ def handle_generate_token_schedule(token):
 
 # Route pour obtenir les métadonnées d’un token public
 @api.route("/tokens/<token>", methods=["GET"])
-@require_auth
 @verify_token
+@measure_time()
 def handle_get_token_metadata(token):
     try:
-        t_0 = time.time()
         calendar_id = g.calendar_id
 
         with get_connection() as conn:
@@ -294,15 +280,12 @@ def handle_get_token_metadata(token):
 
                 owner_uid = token_data.get("owner_uid")
 
-                t_1 = time.time()
-
                 return success_response(
                     message="métadonnées du token récupérées",
                     code="TOKEN_METADATA_SUCCESS",
                     origin="TOKEN_METADATA_FETCH",
                     uid="unknown",
-                    data={"calendar_id": calendar_id, "owner_uid": owner_uid, "time": t_1 - t_0},
-                    log_extra={"token": token, "time": t_1 - t_0}
+                    data={"calendar_id": calendar_id, "owner_uid": owner_uid},
                 )
 
     except Exception as e:
@@ -321,22 +304,21 @@ def handle_get_token_metadata(token):
 @api.route("/tokens/<token>", methods=["DELETE"])
 @require_auth
 @verify_token_owner
+@measure_time()
 def handle_delete_token(token):
     try:
-        t_0 = time.time()
         owner_uid = g.uid
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("DELETE FROM shared_tokens WHERE id = %s", (token,))
-                t_1 = time.time()   
 
                 return success_response(
                     message="token supprimé", 
                     code="TOKEN_DELETE_SUCCESS", 
                     uid=owner_uid, 
                     origin="TOKEN_DELETE", 
-                    log_extra={"token": token, "time": t_1 - t_0}
+                    log_extra={"token": token}
                 )
 
     except Exception as e:

--- a/backend/app/routes/tokens_medicines.py
+++ b/backend/app/routes/tokens_medicines.py
@@ -1,17 +1,17 @@
 from . import api
 from flask import g
-import time
 from app.db.connection import get_connection
 from app.services.calendar import verify_token
 from app.utils.responses import success_response, error_response
+from app.utils.measure import measure_time
 
 
 # Route pour obtenir les médicaments d’un token public
 @api.route("/tokens/<token>/medicines", methods=["GET"])
 @verify_token
+@measure_time()
 def handle_token_medicines(token):
     try:
-        t_0 = time.time()
         calendar_id = g.calendar_id
 
         with get_connection() as conn:
@@ -29,15 +29,13 @@ def handle_token_medicines(token):
                     WHERE box.calendar_id = %s
                 """, (calendar_id,))
                 medicines = cursor.fetchall()
-                t_1 = time.time()
-
 
         return success_response(
             message="médicaments récupérés",
             code="MEDICINES_SHARED_LOADED",
             origin="TOKEN_MEDICINES_LOAD",
             data={"medicines": medicines},
-            log_extra={"token": token, "time": t_1 - t_0}
+            log_extra={"token": token}
         )
 
     except Exception as e:

--- a/backend/app/routes/tokens_medicines.py
+++ b/backend/app/routes/tokens_medicines.py
@@ -8,8 +8,8 @@ from app.utils.measure import measure_time
 
 # Route pour obtenir les médicaments d’un token public
 @api.route("/tokens/<token>/medicines", methods=["GET"])
-@verify_token
 @measure_time()
+@verify_token
 def handle_token_medicines(token):
     try:
         calendar_id = g.calendar_id

--- a/backend/app/routes/tokens_medicines.py
+++ b/backend/app/routes/tokens_medicines.py
@@ -1,32 +1,24 @@
 from . import api
+from flask import g
 import time
 from app.db.connection import get_connection
 from app.services.calendar import verify_token
-from app.utils.responses import success_response, error_response, warning_response
+from app.utils.responses import success_response, error_response
 
 
 # Route pour obtenir les médicaments d’un token public
 @api.route("/tokens/<token>/medicines", methods=["GET"])
+@verify_token
 def handle_token_medicines(token):
     try:
         t_0 = time.time()
-        calendar_id = verify_token(token)
-        if not calendar_id:
-            return warning_response(
-                message="token invalide",
-                code="TOKEN_INVALID",
-                status_code=404,
-                uid="unknown",
-                origin="TOKEN_MEDICINES_LOAD",
-                log_extra={"token": token}
-            )
-            
+        calendar_id = g.calendar_id
 
         with get_connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("""
-                    SELECT 
-                        cond.*,
+                    SELECT
+                        cond.*, 
                         box.name,
                         box.dose,
                         box.box_capacity,

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -9,8 +9,8 @@ from app.utils.measure import measure_time
 
 
 @api.route("/user/sync", methods=["GET"])
-@require_auth
 @measure_time()
+@require_auth
 def get_user_info():
     uid = g.uid
     try:
@@ -43,8 +43,8 @@ def get_user_info():
     
 
 @api.route("/user/update", methods=["POST"])
-@require_auth
 @measure_time()
+@require_auth
 def update_user_info():
     uid = g.uid
     try:
@@ -91,8 +91,8 @@ def update_user_info():
 
 
 @api.route("/user/photo", methods=["POST"])
-@require_auth
 @measure_time()
+@require_auth
 def handle_user_photo():
     uid = None
     try:

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -3,12 +3,14 @@ from flask import request, g
 from app.utils.auth import require_auth
 from app.utils.responses import success_response, error_response
 from app.services.user import fetch_user, update_existing_user, insert_new_user
-import time
 from app.utils.upload import upload_logo
 from app.db.connection import get_connection
+from app.utils.measure import measure_time
+
 
 @api.route("/user/sync", methods=["GET"])
 @require_auth
+@measure_time()
 def get_user_info():
     uid = g.uid
     try:
@@ -42,6 +44,7 @@ def get_user_info():
 
 @api.route("/user/update", methods=["POST"])
 @require_auth
+@measure_time()
 def update_user_info():
     uid = g.uid
     try:
@@ -89,10 +92,10 @@ def update_user_info():
 
 @api.route("/user/photo", methods=["POST"])
 @require_auth
+@measure_time()
 def handle_user_photo():
     uid = None
     try:
-        t_0 = time.time()
         uid = g.uid
 
         photo = request.files.get("photo")
@@ -119,7 +122,7 @@ def handle_user_photo():
             code="USER_PHOTO_SUCCESS",
             uid=uid,
             origin="USER_PHOTO",
-            data={"uid": uid, "photo_url": photo_url, "time": time.time() - t_0}
+            data={"uid": uid, "photo_url": photo_url}
         )
     except Exception as e:
         return error_response(

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -45,8 +45,8 @@ def get_user_info():
 def update_user_info():
     uid = g.uid
     try:
-        user_data = request.get_json()
-        if not user_data:
+        payload = request.get_json(force=True)
+        if not payload:
             return error_response(
                 message="aucune donnée reçue",
                 code="USER_UPDATE_ERROR",
@@ -55,11 +55,11 @@ def update_user_info():
                 origin="USER_UPDATE"
             )
 
-        display_name = user_data.get("display_name", None)
-        email = user_data.get("email", None)
-        photo_url = user_data.get("photo_url", None)
-        email_enabled = user_data.get("email_enabled", None)
-        push_enabled = user_data.get("push_enabled", None)
+        display_name = payload.get("display_name", None)
+        email = payload.get("email", None)
+        photo_url = payload.get("photo_url", None)
+        email_enabled = payload.get("email_enabled", None)
+        push_enabled = payload.get("push_enabled", None)
 
         user_db = fetch_user(uid)
 

--- a/backend/app/services/calendar/verification.py
+++ b/backend/app/services/calendar/verification.py
@@ -1,8 +1,12 @@
+from functools import wraps
+from datetime import datetime, timezone
+from flask import g, request
+
 from app.db.connection import get_connection
 from app.utils.logging import log_backend as logger
-from datetime import datetime, timezone
+from app.utils.responses import warning_response
 
-def verify_calendar_share(calendar_id : str, receiver_uid : str) -> bool:
+def _verify_calendar_share(calendar_id: str, receiver_uid: str) -> bool:
     try:
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -32,7 +36,7 @@ def verify_calendar_share(calendar_id : str, receiver_uid : str) -> bool:
         })
         return False
 
-def verify_calendar(calendar_id : str, uid : str) -> bool:
+def _verify_calendar(calendar_id: str, uid: str) -> bool:
     try:
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -52,7 +56,7 @@ def verify_calendar(calendar_id : str, uid : str) -> bool:
         })
         return False
 
-def verify_token(token : str) -> bool:
+def _verify_token(token: str):
     try:
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -67,11 +71,11 @@ def verify_token(token : str) -> bool:
                 revoked = token_data.get("revoked")
                 permissions = token_data.get("permissions")
 
-                if not verify_calendar(calendar_id, owner_uid):
+                if not _verify_calendar(calendar_id, owner_uid):
                     return False
 
                 now = datetime.now(timezone.utc).date()
-                
+
                 if expires_at and now > expires_at.date():
                     return False
 
@@ -91,7 +95,7 @@ def verify_token(token : str) -> bool:
         })
         return False
 
-def verify_token_owner(token : str, uid : str) -> bool:
+def _verify_token_owner(token: str, uid: str) -> bool:
     try:
         with get_connection() as conn:
             with conn.cursor() as cursor:
@@ -113,3 +117,109 @@ def verify_token_owner(token : str, uid : str) -> bool:
             "error": str(e)
         })
         return False
+
+
+def verify_calendar_share(calendar_id=None, receiver_uid=None):
+    if callable(calendar_id):
+        f = calendar_id
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            cal_id = kwargs.get("calendar_id")
+            if not cal_id and request.view_args:
+                cal_id = request.view_args.get("calendar_id")
+            if not cal_id and request.is_json:
+                body = request.get_json(silent=True) or {}
+                cal_id = body.get("calendarId") or body.get("calendar_id")
+            uid = kwargs.get("receiver_uid") or getattr(g, "uid", None)
+            if not cal_id or not _verify_calendar_share(cal_id, uid):
+                return warning_response(
+                    message="accès refusé",
+                    code="SHARED_VERIFY_DENIED",
+                    uid=uid,
+                    origin="SHARED_VERIFY",
+                )
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return _verify_calendar_share(calendar_id, receiver_uid)
+
+
+def verify_calendar(calendar_id=None, uid=None):
+    if callable(calendar_id):
+        f = calendar_id
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            cal_id = kwargs.get("calendar_id")
+            if not cal_id and request.view_args:
+                cal_id = request.view_args.get("calendar_id")
+            if not cal_id and request.is_json:
+                body = request.get_json(silent=True) or {}
+                cal_id = body.get("calendarId") or body.get("calendar_id")
+            user_id = kwargs.get("uid") or getattr(g, "uid", None)
+            if not cal_id or not _verify_calendar(cal_id, user_id):
+                return warning_response(
+                    message="accès refusé",
+                    code="CALENDAR_VERIFY_DENIED",
+                    uid=user_id,
+                    origin="CALENDAR_VERIFY",
+                )
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return _verify_calendar(calendar_id, uid)
+
+
+def verify_token(token=None):
+    if callable(token):
+        f = token
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            tok = (
+                kwargs.get("token")
+                or request.view_args.get("token") if request.view_args else None
+                or request.args.get("token")
+            )
+            calendar_id = _verify_token(tok)
+            if not calendar_id:
+                return warning_response(
+                    message="token invalide",
+                    code="TOKEN_VERIFY_DENIED",
+                    origin="TOKEN_VERIFY",
+                )
+            g.calendar_id = calendar_id
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return _verify_token(token)
+
+
+def verify_token_owner(token=None, uid=None):
+    if callable(token):
+        f = token
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            tok = (
+                kwargs.get("token")
+                or request.view_args.get("token") if request.view_args else None
+                or request.args.get("token")
+            )
+            user_id = kwargs.get("uid") or getattr(g, "uid", None)
+            if not tok or not _verify_token_owner(tok, user_id):
+                return warning_response(
+                    message="accès refusé",
+                    code="TOKEN_OWNER_VERIFY_DENIED",
+                    uid=user_id,
+                    origin="TOKEN_OWNER_VERIFY",
+                )
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return _verify_token_owner(token, uid)

--- a/backend/app/services/medication/boxes.py
+++ b/backend/app/services/medication/boxes.py
@@ -24,13 +24,13 @@ def get_boxes(calendar_id):
         return []
     return boxes
 
-def update_box(box_id, calendar_id, data):
-    name = data.get("name")
-    dose = data.get("dose")
-    box_capacity = data.get("box_capacity")
-    stock_alert_threshold = data.get("stock_alert_threshold")
-    stock_quantity = data.get("stock_quantity")
-    conditions = data.get("conditions", [])
+def update_box(box_id, calendar_id, box):
+    name = box.get("name")
+    dose = box.get("dose")
+    box_capacity = box.get("box_capacity")
+    stock_alert_threshold = box.get("stock_alert_threshold")
+    stock_quantity = box.get("stock_quantity")
+    conditions = box.get("conditions", [])
 
     with get_connection() as conn:
         with conn.cursor() as cursor:
@@ -49,12 +49,12 @@ def update_box(box_id, calendar_id, data):
                     """, (condition.get("id"), box_id, condition.get("tablet_count"), condition.get("interval_days"), condition.get("start_date"), condition.get("time_of_day")))
             conn.commit()
 
-def create_box(calendar_id, data):
-    name = data.get("name", "nouvelle boite")
-    box_capacity = data.get("box_capacity", 0)
-    stock_alert_threshold = data.get("stock_alert_threshold", 10)
-    stock_quantity = data.get("stock_quantity", 0)
-    dose = data.get("dose", 0)
+def create_box(calendar_id, box):
+    name = box.get("name", "nouvelle boite")
+    box_capacity = box.get("box_capacity", 0)
+    stock_alert_threshold = box.get("stock_alert_threshold", 10)
+    stock_quantity = box.get("stock_quantity", 0)
+    dose = box.get("dose", 0)
 
     with get_connection() as conn:
         with conn.cursor() as cursor:

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -2,3 +2,4 @@ from .auth import *
 from .logging import *
 from .responses import *
 from .upload import *
+from .measure import *

--- a/backend/app/utils/measure.py
+++ b/backend/app/utils/measure.py
@@ -1,0 +1,22 @@
+# app/utils/measure.py (inchangé ou juste g._t0 au début)
+import time
+from functools import wraps
+from flask import g
+
+def measure_time():
+    def decorator(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            if not hasattr(g, "_t0"):
+                g._t0 = time.perf_counter()
+            try:
+                return f(*args, **kwargs)
+            finally:
+                g.elapsed_time = round(time.perf_counter() - g._t0, 6)
+        return wrapped
+    return decorator
+
+def elapsed_now():
+    if hasattr(g, "_t0"):
+        return round(time.perf_counter() - g._t0, 6)
+    return None

--- a/backend/app/utils/responses.py
+++ b/backend/app/utils/responses.py
@@ -1,65 +1,68 @@
-from flask import jsonify
+from flask import jsonify, g
 from app.utils.logging import log_backend as logger
+import time
 
-#exemple de log_extra : {'calendar_id': '98fb17305b9a8005b603b51f4820f30d', 'uid': '98fb17305b9a8005b603b51f4820f30d'}
+
+def _merge_log_extra(log_extra=None):
+    log_extra = dict(log_extra or {})
+    if "time" not in log_extra and hasattr(g, "_t0"):
+        log_extra["time"] = round(time.perf_counter() - g._t0, 6)
+    return log_extra
+
+# exemple de log_extra : {'calendar_id': '...', 'uid': '...'}
 
 def success_response(message, code, uid=None, origin=None, data=None, log_extra=None):
-    log_extra = log_extra or {}
-
     payload = {"message": message, "code": code}
-    
-    if data:
-        payload.update(data)
 
-    if log_extra:
-        log_extra["code"] = code
-    else:
-        log_extra = {"code": code} 
+    # Rétro-compat + progressif :
+    # - si data est un dict : on met payload["data"]=data ET on aplati dans payload
+    # - sinon : on met juste payload["data"]=data
+    if data is not None:
+        payload["data"] = data
+        if isinstance(data, dict):
+            payload.update(data)
+
+    merged_extra = _merge_log_extra(log_extra)
+    merged_extra["code"] = code
 
     if origin and uid:
         logger.info(message, {
             "origin": origin,
             "uid": uid,
-            **log_extra
+            **merged_extra
         })
 
     return jsonify(payload), 200
 
 
 def error_response(message, code, status_code=500, uid=None, origin=None, error=None, log_extra=None):
-    log_extra = log_extra or {}
-
     payload = {"error": message, "code": code}
 
-    if log_extra:
-        log_extra["code"] = code
-    else:
-        log_extra = {"code": code} 
+    merged_extra = _merge_log_extra(log_extra)
+    merged_extra["code"] = code
+
     if origin and uid:
         logger.error(message, {
             "origin": origin,
             "uid": uid,
-            "error": str(error),
-            **log_extra
+            "error": str(error) if error is not None else None,
+            **merged_extra
         })
 
     return jsonify(payload), status_code
 
 
 def warning_response(message, code, status_code=400, uid=None, origin=None, log_extra=None):
-    log_extra = log_extra or {}
-
     payload = {"error": message, "code": code}
 
-    if log_extra:
-        log_extra["code"] = code
-    else:
-        log_extra = {"code": code} 
+    merged_extra = _merge_log_extra(log_extra)
+    merged_extra["code"] = code
+
     if origin and uid:
         logger.warning(message, {
             "origin": origin,
             "uid": uid,
-            **log_extra
+            **merged_extra
         })
 
     return jsonify(payload), status_code

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,9 +54,8 @@ function App() {
   // Fonction pour supprimer un calendrier
   const deleteCalendar = useCallback(async (calendarId) => {
     return await performApiCall({
-      url: `${API_URL}/api/calendars`,
+      url: `${API_URL}/api/calendars/${calendarId}`,
       method: 'DELETE',
-      body: { calendarId },
       origin: 'CALENDAR_DELETE',
       uid,
       analyticsEvent: 'delete_calendar',
@@ -68,9 +67,9 @@ function App() {
   // Fonction pour renommer un calendrier
   const renameCalendar = useCallback(async (calendarId, newCalendarName) => {
     return await performApiCall({
-      url: `${API_URL}/api/calendars`,
+      url: `${API_URL}/api/calendars/${calendarId}`,
       method: 'PUT',
-      body: { calendarId, newCalendarName },
+      body: { newCalendarName },
       origin: 'CALENDAR_RENAME',
       uid,
       analyticsEvent: 'rename_calendar',
@@ -88,7 +87,7 @@ function App() {
     const start = startDate || formatToLocalISODate(new Date());
 
     const result = await performApiCall({
-      url: `${API_URL}/api/calendars/${calendarId}/schedule?startTime=${start}`,
+      url: `${API_URL}/api/calendars/${calendarId}/schedule?startDate=${start}`,
       method: 'GET',
       origin: 'CALENDAR_FETCH',
       uid,
@@ -96,7 +95,7 @@ function App() {
       analyticsData: {
         calendarId,
         uid,
-        startTime: start,
+        startDate: start,
       },
     });
 
@@ -128,7 +127,7 @@ function App() {
     return await performApiCall({
       url: `${API_URL}/api/calendars/${calendarId}/boxes/${boxId}`,
       method: 'PUT',
-      body: box,
+      body: { box },
       origin: 'BOX_UPDATE',
       uid,
       analyticsEvent: 'update_personal_box',
@@ -142,11 +141,13 @@ function App() {
     const result = await performApiCall({
       url: `${API_URL}/api/calendars/${calendarId}/boxes`,
       method: 'POST',
-      body: {
-        name,
-        box_capacity: boxCapacity,
-        stock_alert_threshold: stockAlertThreshold,
-        stock_quantity: stockQuantity,
+      body: { 
+        box: {
+          name,
+          box_capacity: boxCapacity,
+          stock_alert_threshold: stockAlertThreshold,
+          stock_quantity: stockQuantity,
+        }
       },
       origin: 'BOX_CREATE',
       uid,
@@ -185,14 +186,15 @@ function App() {
 
   // fonction pour diminuer le stock du pillulier
   const useMedicinesForPersonalPillbox   = useCallback(async (calendarId, startDate = null) => {
-    const startTime = startDate || formatToLocalISODate(new Date());
+    const start = startDate || formatToLocalISODate(new Date());
     return await performApiCall({
-      url: `${API_URL}/api/calendars/${calendarId}/pilluliers/used?startTime=${startTime}`,
+      url: `${API_URL}/api/calendars/${calendarId}/pilluliers/used`,
       method: 'POST',
+      body: { startDate: start },
       origin: 'PILLULIER_USE_MEDICATION',
       uid,
       analyticsEvent: 'use_pillulier_medication',
-      analyticsData: { calendarId, uid },
+      analyticsData: { calendarId, uid, startDate: start },
     });
   }, []);
 
@@ -250,7 +252,7 @@ function App() {
     const start = startDate || formatToLocalISODate(new Date());
 
     const result = await performApiCall({
-      url: `${API_URL}/api/tokens/${token}/schedule?startTime=${start}`,
+      url: `${API_URL}/api/tokens/${token}/schedule?startDate=${start}`,
       method: 'GET',
       origin: 'SHARED_CALENDAR_FETCH',
       analyticsEvent: 'fetch_token_calendar_schedule',
@@ -452,15 +454,15 @@ function App() {
   // Fonction pour recup le calendrier partagé par un utilisateur
   const fetchSharedUserCalendarSchedule = useCallback(
     async (calendarId, startDate = null) => {
-      const startTime = startDate || formatToLocalISODate(new Date());
+      const start = startDate || formatToLocalISODate(new Date());
   
       const response = await performApiCall({
-        url: `${API_URL}/api/shared/users/calendars/${calendarId}/schedule?startTime=${startTime}`,
+        url: `${API_URL}/api/shared/users/calendars/${calendarId}/schedule?startDate=${start}`,
         method: 'GET',
         origin: 'SHARED_USER_CALENDAR_FETCH',
         uid,
         analyticsEvent: 'fetch_shared_user_calendar_schedule',
-        analyticsData: { calendarId, uid, startTime },
+        analyticsData: { calendarId, uid, startDate: start },
       });
   
       if (response.success) {
@@ -489,7 +491,7 @@ function App() {
     return await performApiCall({
       url: `${API_URL}/api/shared/users/calendars/${calendarId}/boxes/${boxId}`,
       method: 'PUT',
-      body: box,
+      body: { box },
       origin: 'SHARED_BOX_UPDATE',
       uid,
       analyticsEvent: 'update_shared_user_box',
@@ -511,10 +513,12 @@ function App() {
         url: `${API_URL}/api/shared/users/calendars/${calendarId}/boxes`,
         method: 'POST',
         body: {
-          name,
-          box_capacity: boxCapacity,
-          stock_alert_threshold: stockAlertThreshold,
-          stock_quantity: stockQuantity,
+          box: {
+            name,
+            box_capacity: boxCapacity,
+            stock_alert_threshold: stockAlertThreshold,
+            stock_quantity: stockQuantity,
+          },
         },
         origin: 'SHARED_BOX_CREATE',
         uid,
@@ -549,14 +553,15 @@ function App() {
 
   // Fonction pour diminuer le stock du pillulier
   const useMedicinesForSharedUserPillbox = useCallback(async (calendarId, startDate = null) => {
-    const startTime = startDate || formatToLocalISODate(new Date());
+    const start = startDate || formatToLocalISODate(new Date());
     return await performApiCall({
-      url: `${API_URL}/api/shared/users/calendars/${calendarId}/pilluliers/used?startTime=${startTime}`,
+      url: `${API_URL}/api/shared/users/calendars/${calendarId}/pilluliers/used`,
       method: 'POST',
+      body: { startDate: start },
       origin: 'SHARED_USER_PILLULIER_USE_MEDICATION',
       uid,
       analyticsEvent: 'use_shared_user_pillulier_medication',
-      analyticsData: { calendarId, startTime },
+      analyticsData: { calendarId, startDate: start },
     });
   }, []);
 

--- a/frontend/src/pages/medicines/BoxesView.jsx
+++ b/frontend/src/pages/medicines/BoxesView.jsx
@@ -301,7 +301,7 @@ function BoxCard({
   };
 
   const openNotice = (box_id) => {
-    const url = `${import.meta.env.VITE_API_URL}/api/proxy/pdf?box_id=${box_id}`;
+    const url = `${import.meta.env.VITE_API_URL}/api/proxy/pdf/${box_id}`;
     window.open(url, '_blank');
   };
 


### PR DESCRIPTION
## Summary
- refactor calendar and token verification helpers into dual-purpose wrappers for decorator-style use
- apply verification decorators across token and shared user medicine routes to replace manual access checks
- extend decorator usage to invitations, calendar scheduling, shared user, and personal medicine endpoints
- allow calendar verification wrappers to read IDs from JSON bodies and guard calendar deletion, renaming, and shared user removal

## Testing
- `cd backend && python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb26794d88328978c76a8fccf195f