### PR TITLE
feat: add language-prefixed routing and localized index template

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -16,7 +16,9 @@ from .notifications import *
 from .user import *
 from .pdf import *
 from .gemini import *
+from .frontend import frontend
 
 
 def register_routes(app):
     app.register_blueprint(api, url_prefix='/api')
+    app.register_blueprint(frontend)

--- a/backend/app/routes/frontend.py
+++ b/backend/app/routes/frontend.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, render_template, request, abort
+from app.seo.meta_config import META
+
+SUPPORTED_LANGS = list(META.keys())
+
+frontend = Blueprint('frontend', __name__, template_folder='../templates')
+
+@frontend.route('/', defaults={'path': ''})
+@frontend.route('/<path:path>')
+def serve_frontend(path):
+    if path.startswith('api'):
+        abort(404)
+    segments = [seg for seg in path.split('/') if seg]
+    lang = segments[0] if segments and segments[0] in SUPPORTED_LANGS else 'fr'
+    remaining = '/' + '/'.join(segments[1:]) if len(segments) > 1 else '/'
+    meta = META.get(lang, META['fr'])
+    base = request.url_root.rstrip('/')
+    alternates = []
+    for l in SUPPORTED_LANGS:
+        url = f"{base}/{l}{'' if remaining == '/' else remaining}"
+        alternates.append({'lang': l, 'url': url})
+    current_url = f"{base}/{lang}{'' if remaining == '/' else remaining}"
+    return render_template('index.html.j2', lang=lang, meta=meta, alternates=alternates, current_url=current_url)

--- a/backend/app/seo/meta_config.py
+++ b/backend/app/seo/meta_config.py
@@ -1,0 +1,47 @@
+META = {
+    "fr": {
+        "title": "MediTime – Gérez vos traitements",
+        "description": "Gérez, suivez et partagez vos traitements médicaux facilement.",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+    "en": {
+        "title": "MediTime – Manage your treatments",
+        "description": "Easily manage, track and share your medical treatments.",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+    "es": {
+        "title": "MediTime – Gestiona tus tratamientos",
+        "description": "Gestiona, sigue y comparte fácilmente tus tratamientos médicos.",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+    "de": {
+        "title": "MediTime – Verwalte deine Behandlungen",
+        "description": "Verwalte, verfolge und teile deine medizinischen Behandlungen ganz einfach.",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+    "it": {
+        "title": "MediTime – Gestisci i tuoi trattamenti",
+        "description": "Gestisci, monitora e condividi facilmente i tuoi trattamenti medici.",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+    "ja": {
+        "title": "MediTime – 治療を管理しましょう",
+        "description": "医療治療を簡単に管理、追跡、共有できます。",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+    "zh": {
+        "title": "MediTime – 管理您的治疗",
+        "description": "轻松管理、跟踪并分享您的医疗治疗。",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+    "pt": {
+        "title": "MediTime – Gerencie seus tratamentos",
+        "description": "Gerencie, acompanhe e compartilhe seus tratamentos médicos com facilidade.",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+    "ru": {
+        "title": "MediTime – Управляйте своим лечением",
+        "description": "Легко управляйте, отслеживайте и делитесь своим медицинским лечением.",
+        "image": "https://meditime-app.com/icons/logo.webp",
+    },
+}

--- a/backend/app/templates/index.html.j2
+++ b/backend/app/templates/index.html.j2
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="{{ meta.description }}" />
+    <meta property="og:title" content="{{ meta.title }}" />
+    <meta property="og:description" content="{{ meta.description }}" />
+    <meta property="og:image" content="{{ meta.image }}" />
+    <meta property="og:url" content="{{ current_url }}" />
+    {% for alt in alternates %}
+    <link rel="alternate" hreflang="{{ alt.lang }}" href="{{ alt.url }}" />
+    {% endfor %}
+    {% if alternates %}
+    <link rel="alternate" hreflang="x-default" href="{{ alternates[0].url }}" />
+    {% endif %}
+    <title>{{ meta.title }}</title>
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+    <link rel="icon" href="/icons/favicon.ico" sizes="any" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <div id="modal-container"></div>
+    <script type="module" src="/src/index.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 // App.js
 import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { getLangFromPath, DEFAULT_LANG } from './i18n/langRoutes';
 import Navbar from './components/common/Header';
 import Footer from './components/common/Footer';
 import AppRoutes from './routes/AppRouter';
@@ -10,12 +11,11 @@ import { formatToLocalISODate } from './utils/calendar/dateUtils';
 import RealtimeManager from './components/realtime/RealtimeManager';
 import { getToken } from './services/supabase/tokenUtils';
 import { performApiCall } from './services/api/apiUtils';
-import { useTranslation } from 'react-i18next';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
 function App() {
-  const { t } = useTranslation();
+  const currentLang = getLangFromPath(window.location.pathname) || DEFAULT_LANG;
   const [tokensList, setTokensList] = useState([]);
   const [calendarsData, setCalendarsData] = useState(null);
   const [notificationsData, setNotificationsData] = useState(null);
@@ -829,7 +829,7 @@ function App() {
   }, [userInfo?.uid]);
 
   return (
-    <Router>
+    <Router basename={`/${currentLang}`}>
       <div className="d-flex flex-column min-vh-100">
         <Navbar sharedProps={sharedProps} />
         <main className="flex-grow-1 d-flex flex-column pb-5 pb-lg-0">

--- a/frontend/src/components/common/LanguageSelector.jsx
+++ b/frontend/src/components/common/LanguageSelector.jsx
@@ -2,10 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactFlagsSelect from 'react-flags-select';
 import { LANGUAGES } from '../../config/languages';
+import { stripLangFromPath, localizePath, SUPPORTED_LANGS } from '../../i18n/langRoutes';
+import { useLocation } from 'react-router-dom';
 
 function LanguageSelector() {
-  const { i18n, t  } = useTranslation();
+  const { i18n } = useTranslation();
   const [selected, setSelected] = useState('FR');
+  const location = useLocation();
 
   useEffect(() => {
     const currentLang = LANGUAGES.find(lang => lang.code === i18n.language);
@@ -17,6 +20,11 @@ function LanguageSelector() {
     if (lang) {
       i18n.changeLanguage(lang.code);
       setSelected(lang.flag);
+      if (SUPPORTED_LANGS.includes(lang.code)) {
+        const path = stripLangFromPath(location.pathname);
+        const target = localizePath(path, lang.code) + location.search + location.hash;
+        window.location.assign(target);
+      }
     }
   };
 

--- a/frontend/src/i18n/index.js
+++ b/frontend/src/i18n/index.js
@@ -1,9 +1,9 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import { enabledLanguageCodes } from './config/languages';
+import { enabledLanguageCodes } from '../config/languages';
 
-const translationFiles = import.meta.glob('./locales/*/translation.json', { eager: true });
+const translationFiles = import.meta.glob('../locales/*/translation.json', { eager: true });
 
 const resources = {};
 

--- a/frontend/src/i18n/langRoutes.ts
+++ b/frontend/src/i18n/langRoutes.ts
@@ -1,0 +1,22 @@
+import { enabledLanguageCodes } from '../config/languages';
+
+export const SUPPORTED_LANGS = enabledLanguageCodes as string[];
+export type Lang = (typeof SUPPORTED_LANGS)[number];
+export const DEFAULT_LANG: Lang = 'fr';
+
+export function getLangFromPath(pathname: string): Lang | null {
+  const segment = pathname.split('/')[1];
+  return (SUPPORTED_LANGS as readonly string[]).includes(segment) ? (segment as Lang) : null;
+}
+
+export function stripLangFromPath(pathname: string): string {
+  const lang = getLangFromPath(pathname);
+  if (!lang) return pathname;
+  const parts = pathname.split('/').slice(2);
+  return '/' + parts.join('/');
+}
+
+export function localizePath(path: string, lang: Lang): string {
+  if (!path.startsWith('/')) path = '/' + path;
+  return `/${lang}${path}`;
+}

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -4,7 +4,21 @@ import './styles/index.css';
 import './styles/bootstrap.min.css';
 import App from './App';
 import { UserProvider } from './contexts/UserContext';
-import './i18n';
+import i18n from './i18n';
+import { getLangFromPath, localizePath, SUPPORTED_LANGS, DEFAULT_LANG } from './i18n/langRoutes';
+
+const { pathname, search, hash } = window.location;
+const langFromUrl = getLangFromPath(pathname);
+
+if (langFromUrl) {
+  if (i18n.language !== langFromUrl) {
+    i18n.changeLanguage(langFromUrl);
+  }
+} else {
+  const detected = SUPPORTED_LANGS.includes(i18n.language) ? (i18n.language) : DEFAULT_LANG;
+  const target = localizePath(pathname, detected) + search + hash;
+  window.location.replace(target);
+}
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- add client-side language-prefixed routing with i18n detection
- serve localized HTML template with language-specific meta and hreflang
- register frontend blueprint and cleanup legacy i18n path
- extend routing and meta config to all available locales

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `python -m py_compile backend/app/routes/frontend.py backend/app/seo/meta_config.py`
- `PYTHONPATH=backend python backend/app/main.py --check` *(fails: GOOGLE_APPLICATION_CREDENTIALS manquant)*

------
https://chatgpt.com/codex/tasks/task_e_689da993feb0832883a9b9bb411d1670