### PR TITLE
feat: add basic multilingual routing and seo

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,34 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset 
-  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
 
   <url>
-    <loc>https://meditime-app.com/home</loc>
+    <loc>https://meditime-app.com/fr/home</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/home" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/home" />
     <priority>1.0</priority>
   </url>
 
   <url>
-    <loc>https://meditime-app.com/login</loc>
+    <loc>https://meditime-app.com/fr/login</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/login" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/login" />
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://meditime-app.com/register</loc>
+    <loc>https://meditime-app.com/fr/register</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/register" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/register" />
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://meditime-app.com/reset-password</loc>
-    <priority>0.5</priority>
-  </url>
-  
-  <url>
-    <loc>https://meditime-app.com/reset-password-confirm</loc>
+    <loc>https://meditime-app.com/fr/reset-password</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/reset-password" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/reset-password" />
     <priority>0.5</priority>
   </url>
 
   <url>
-    <loc>https://meditime-app.com/verify-email</loc>
+    <loc>https://meditime-app.com/fr/reset-password-confirm</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/reset-password-confirm" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/reset-password-confirm" />
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://meditime-app.com/fr/verify-email</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/verify-email" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/verify-email" />
     <priority>0.5</priority>
   </url>
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 // App.js
 import React, { useState, useEffect, useContext, useCallback } from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import Navbar from './components/common/Header';
 import Footer from './components/common/Footer';
 import AppRoutes from './routes/AppRouter';
@@ -11,11 +11,13 @@ import RealtimeManager from './components/realtime/RealtimeManager';
 import { getToken } from './services/supabase/tokenUtils';
 import { performApiCall } from './services/api/apiUtils';
 import { useTranslation } from 'react-i18next';
+import { getLocale } from './config/languages';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
 function App() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const { lng } = useParams();
   const [tokensList, setTokensList] = useState([]);
   const [calendarsData, setCalendarsData] = useState(null);
   const [notificationsData, setNotificationsData] = useState(null);
@@ -828,28 +830,33 @@ function App() {
     sendTokenToBackend();
   }, [userInfo?.uid]);
 
-  return (
-    <Router>
-      <div className="d-flex flex-column min-vh-100">
-        <Navbar sharedProps={sharedProps} />
-        <main className="flex-grow-1 d-flex flex-column pb-5 pb-lg-0">
-          {userInfo && (
-            <RealtimeManager
-              setCalendarsData={setCalendarsData}
-              setSharedCalendarsData={setSharedCalendarsData}
-              setNotificationsData={setNotificationsData}
-              setTokensList={setTokensList}
-              setLoadingStates={setLoadingStates}
-            />
-          )}
+  useEffect(() => {
+    if (lng && i18n.language !== lng) {
+      i18n.changeLanguage(lng);
+    }
+    document.documentElement.setAttribute('lang', getLocale(lng));
+  }, [lng, i18n]);
 
-          <div className="container mt-4 pb-5 pb-lg-0">
-            <AppRoutes sharedProps={sharedProps} />
-          </div>
-        </main>
-        <Footer />
-      </div>
-    </Router>
+  return (
+    <div className="d-flex flex-column min-vh-100">
+      <Navbar sharedProps={sharedProps} />
+      <main className="flex-grow-1 d-flex flex-column pb-5 pb-lg-0">
+        {userInfo && (
+          <RealtimeManager
+            setCalendarsData={setCalendarsData}
+            setSharedCalendarsData={setSharedCalendarsData}
+            setNotificationsData={setNotificationsData}
+            setTokensList={setTokensList}
+            setLoadingStates={setLoadingStates}
+          />
+        )}
+
+        <div className="container mt-4 pb-5 pb-lg-0">
+          <AppRoutes sharedProps={sharedProps} />
+        </div>
+      </main>
+      <Footer />
+    </div>
   );
 }
 

--- a/frontend/src/Root.jsx
+++ b/frontend/src/Root.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+} from 'react-router-dom';
+import App from './App';
+import { useTranslation } from 'react-i18next';
+import { enabledLanguageCodes, LANGUAGES } from './config/languages';
+
+function LanguageRoutes() {
+  const location = useLocation();
+  const { i18n } = useTranslation();
+  const defaultLang = i18n.language || LANGUAGES[0].code;
+  const pathParts = location.pathname.split('/');
+  const currentLang = pathParts[1];
+
+  if (!enabledLanguageCodes.includes(currentLang)) {
+    const path = location.pathname + location.search + location.hash;
+    return <Navigate to={`/${defaultLang}${path}`} replace />;
+  }
+
+  return (
+    <Routes>
+      <Route path="/:lng/*" element={<App />} />
+    </Routes>
+  );
+}
+
+export default function Root() {
+  return (
+    <BrowserRouter>
+      <LanguageRoutes />
+    </BrowserRouter>
+  );
+}
+

--- a/frontend/src/components/calendar/PillboxDisplay.jsx
+++ b/frontend/src/components/calendar/PillboxDisplay.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { UserContext } from '../../contexts/UserContext';
 import { getCalendarSourceMap } from '../../utils/calendar/calendarSourceMap';
 import isEqual from 'lodash/isEqual';
@@ -27,6 +27,7 @@ export default function PillboxDisplay({
   const { t } = useTranslation();
   const { userInfo } = useContext(UserContext);
   const navigate = useNavigate();
+  const { lng } = useParams();
   const [calendarTable, setCalendarTable] = useState([]);
   const [selectedMedIndex, setSelectedMedIndex] = useState(0);
   const [orderedMeds, setOrderedMeds] = useState([]);
@@ -118,7 +119,7 @@ export default function PillboxDisplay({
                 setSuccessMessage(true);
               } else if (type === 'pillbox') {
                 calendarSource.decreaseStock(calendarId);
-                navigate(`/${basePath}/${calendarId}`);
+                navigate(`/${lng}/${basePath}/${calendarId}`);
               }
               setShowConfirmation(false);
             }}

--- a/frontend/src/components/common/Footer.jsx
+++ b/frontend/src/components/common/Footer.jsx
@@ -1,10 +1,11 @@
 import React, { useContext } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { UserContext } from '../../contexts/UserContext';
 import { useTranslation } from 'react-i18next';
 
 function Footer() {
   const location = useLocation();
+  const { lng } = useParams();
   const { userInfo } = useContext(UserContext);
   const { t } = useTranslation();
 
@@ -15,7 +16,8 @@ function Footer() {
     '/verify-email',
   ];
 
-  const shouldShowFooter = !hiddenFooterRoutes.includes(location.pathname);
+  const pathAfterLang = '/' + location.pathname.split('/').slice(2).join('/');
+  const shouldShowFooter = !hiddenFooterRoutes.includes(pathAfterLang);
   if (!shouldShowFooter) return null;
 
   const currentYear = new Date().getFullYear();
@@ -32,7 +34,7 @@ function Footer() {
                   <li>
                     <i className="bi bi-house me-2 text-primary" aria-hidden="true"></i>
                     <Link
-                      to="/home"
+                      to={`/${lng}/home`}
                       className="text-muted text-decoration-none link-hover"
                     >
                       {t('home')}
@@ -41,7 +43,7 @@ function Footer() {
                   <li>
                     <i className="bi bi-info-circle me-2 text-primary" aria-hidden="true"></i>
                     <Link
-                      to="/about"
+                      to={`/${lng}/about`}
                       className="text-muted text-decoration-none link-hover"
                     >
                       {t('about')}
@@ -50,7 +52,7 @@ function Footer() {
                   <li>
                     <i className="bi bi-file-earmark-text me-2 text-primary" aria-hidden="true"></i>
                     <Link
-                      to="/terms"
+                      to={`/${lng}/terms`}
                       className="text-muted text-decoration-none link-hover"
                     >
                       {t('terms.label')}
@@ -59,7 +61,7 @@ function Footer() {
                   <li>
                     <i className="bi bi-shield-lock me-2 text-primary" aria-hidden="true"></i>
                     <Link
-                      to="/privacy"
+                      to={`/${lng}/privacy`}
                       className="text-muted text-decoration-none link-hover"
                     >
                       {t('privacy.label')}
@@ -72,8 +74,8 @@ function Footer() {
                   <ul className="list-unstyled">
                     <li>
                       <i className="bi bi-person-gear me-2 text-primary" aria-hidden="true"></i>
-                      <Link
-                        to="/account"
+                        <Link
+                        to={`/${lng}/account`}
                         className="text-muted text-decoration-none link-hover"
                       >
                         {t('account.label')}
@@ -82,7 +84,7 @@ function Footer() {
                     <li>
                       <i className="bi bi-calendar2-week me-2 text-primary" aria-hidden="true"></i>
                       <Link
-                        to="/calendars"
+                        to={`/${lng}/calendars`}
                         className="text-muted text-decoration-none link-hover"
                       >
                         {t('my_calendars')}
@@ -91,7 +93,7 @@ function Footer() {
                     <li>
                       <i className="bi bi-box-arrow-up me-2 text-primary" aria-hidden="true"></i>
                       <Link
-                        to="/shared-calendars"
+                        to={`/${lng}/shared-calendars`}
                         className="text-muted text-decoration-none link-hover"
                       >
                         {t('shared_calendars')}
@@ -100,7 +102,7 @@ function Footer() {
                     <li>
                       <i className="bi bi-bell me-2 text-primary" aria-hidden="true"></i>
                       <Link
-                        to="/notifications"
+                        to={`/${lng}/notifications`}
                         className="text-muted text-decoration-none link-hover"
                       >
                         {t('notifications')}
@@ -139,9 +141,9 @@ function Footer() {
           </div>
 
           {/* Logo + copyright */}
-          <Link 
+          <Link
             className='col-md-4 text-decoration-none link-hover'
-            to="/"
+            to={`/${lng}`}
           >
             <div className="text-md-end text-center">
               <div className="fw-bold text-primary fs-5">

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState, useRef } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { UserContext } from '../../contexts/UserContext';
 import { handleLogout } from '../../services/auth/authService';
 import { useNavigate } from 'react-router-dom';
@@ -13,6 +13,7 @@ function Navbar({ sharedProps }) {
   const { userInfo } = useContext(UserContext);
   const navigate = useNavigate();
   const location = useLocation();
+  const { lng } = useParams();
   const { t } = useTranslation();
   const [calendarInfo, setCalendarInfo] = useState(null);
   const [basePath, setBasePath] = useState(null);
@@ -21,13 +22,15 @@ function Navbar({ sharedProps }) {
   const notifRef = useRef();
   const userRef = useRef();
   const [tokenId, setTokenId] = useState(null);
+  const pathAfterLang = location.pathname.split('/').slice(2).join('/');
+  const pathWithSlash = '/' + pathAfterLang;
   const locationList = {
-    calendar: location.pathname.startsWith('/calendar/'),
-    sharedUserCalendar: location.pathname.startsWith('/shared-user-calendar/'),
-    tokenCalendar: location.pathname.startsWith('/shared-token-calendar/'),
+    calendar: pathWithSlash.startsWith('/calendar/'),
+    sharedUserCalendar: pathWithSlash.startsWith('/shared-user-calendar/'),
+    tokenCalendar: pathWithSlash.startsWith('/shared-token-calendar/'),
   };
 
-  const pathParts = location.pathname.split('/').filter(Boolean);
+  const pathParts = pathAfterLang.split('/').filter(Boolean);
 
   const locationAvailableForReturnToCalendarList = {
     calendar: 
@@ -59,7 +62,7 @@ function Navbar({ sharedProps }) {
       setBasePath('calendar');
       setCalendarInfo(
         sharedProps.personalCalendars.calendarsData.find(
-          (calendar) => calendar.id === location.pathname.split('/')[2]
+          (calendar) => calendar.id === pathParts[1]
         )
       );
     } else if (
@@ -69,12 +72,12 @@ function Navbar({ sharedProps }) {
       setBasePath('shared-user-calendar');
       setCalendarInfo(
         sharedProps.sharedUserCalendars.sharedCalendarsData.find(
-          (calendar) => calendar.id === location.pathname.split('/')[2]
+          (calendar) => calendar.id === pathParts[1]
         )
       );
     } else if (locationList.tokenCalendar) {
       setBasePath('shared-token-calendar');
-      setTokenId(location.pathname.split('/')[2]);
+      setTokenId(pathParts[1]);
     } else {
       setCalendarInfo(null);
       setBasePath(null);
@@ -104,7 +107,7 @@ function Navbar({ sharedProps }) {
   if (isPillboxPage) {
     return (
       <Link
-        to={`/${basePath}/${calendarInfo?.id}`}
+        to={`/${lng}/${basePath}/${calendarInfo?.id}`}
         className="fs-2 text-dark align-self-end"
         style={{
           position: 'fixed',
@@ -127,7 +130,7 @@ function Navbar({ sharedProps }) {
           {/* Logo / Retour */}
           {locationAvailableForReturnToCalendarList.calendar ||
           locationAvailableForReturnToCalendarList.sharedUserCalendar ? (
-            <Link to="/calendars" className="navbar-brand fs-4">
+            <Link to={`/${lng}/calendars`} className="navbar-brand fs-4">
               <i className="bi bi-arrow-left"></i> {t('back')}
             </Link>
           ) : calendarInfo?.id &&
@@ -135,7 +138,7 @@ function Navbar({ sharedProps }) {
             (locationAvailableForReturnToCalendar.calendar ||
               locationAvailableForReturnToCalendar.sharedUserCalendar) ? (
             <Link
-              to={`/${basePath}/${calendarInfo.id}`}
+              to={`/${lng}/${basePath}/${calendarInfo.id}`}
               className="navbar-brand fs-4"
             >
               <i className="bi bi-arrow-left"></i> {t('back')}
@@ -144,13 +147,13 @@ function Navbar({ sharedProps }) {
             tokenId &&
             locationAvailableForReturnToCalendar.tokenCalendar ? (
             <Link
-              to={`/shared-token-calendar/${tokenId}`}
+              to={`/${lng}/shared-token-calendar/${tokenId}`}
               className="navbar-brand fs-4"
             >
               <i className="bi bi-arrow-left"></i> {t('back')}
             </Link>
           ) : (
-            <Link to="/" className="navbar-brand fw-bold text-primary fs-4">
+            <Link to={`/${lng}/home`} className="navbar-brand fw-bold text-primary fs-4">
               <i className="bi bi-capsule"></i> {t('app.title')}
             </Link>
           )}
@@ -165,7 +168,7 @@ function Navbar({ sharedProps }) {
                   <h4 className="m-0">
                     {calendarInfo && basePath && calendarInfo.id && (
                       <Link
-                        to={`/${basePath}/${calendarInfo.id}`}
+                        to={`/${lng}/${basePath}/${calendarInfo.id}`}
                         className="text-decoration-none text-dark"
                       >
                         <span className="text-muted">{t('calendar.label')} : </span>
@@ -188,7 +191,7 @@ function Navbar({ sharedProps }) {
                   )}
                   {locationList.tokenCalendar && tokenId && (
                     <Link
-                      to={`/shared-token-calendar/${tokenId}`}
+                      to={`/${lng}/shared-token-calendar/${tokenId}`}
                       className="text-decoration-none text-dark"
                     >
                       <div className="badge bg-info mt-2">
@@ -204,7 +207,7 @@ function Navbar({ sharedProps }) {
                 {calendarInfo && basePath && calendarInfo.id && (
                   <h4 className="m-1 fw-bold">
                     <Link
-                      to={`/${basePath}/${calendarInfo.id}`}
+                      to={`/${lng}/${basePath}/${calendarInfo.id}`}
                       className="text-decoration-none text-dark"
                     >
                       {calendarInfo.name}
@@ -225,7 +228,7 @@ function Navbar({ sharedProps }) {
                 )}
                 {locationList.tokenCalendar && tokenId && (
                   <Link
-                    to={`/shared-token-calendar/${tokenId}`}
+                    to={`/${lng}/shared-token-calendar/${tokenId}`}
                     className="text-decoration-none text-dark"
                   >
                     <div className="badge bg-info">
@@ -241,18 +244,18 @@ function Navbar({ sharedProps }) {
           <div className="d-none d-lg-flex align-items-center">
             <ul className="navbar-nav align-items-center gap-2">
               <li className="nav-item">
-                <Link to="/calendars" className="nav-link">
+                <Link to={`/${lng}/calendars`} className="nav-link">
                   <i className="bi bi-calendar-date fs-5"></i> {t('calendars')}
                 </Link>
               </li>
               <li className="nav-item">
-                <Link to="/shared-calendars" className="nav-link">
+                <Link to={`/${lng}/shared-calendars`} className="nav-link">
                   <i className="bi bi-box-arrow-up fs-5"></i> {t('shared')}
                 </Link>
               </li>
               {userInfo?.role === 'admin' && (
                 <li className="nav-item">
-                  <Link to="/admin" className="nav-link">
+                  <Link to={`/${lng}/admin`} className="nav-link">
                     <i className="bi bi-lock fs-5"></i> {t('admin')}
                   </Link>
                 </li>
@@ -323,7 +326,7 @@ function Navbar({ sharedProps }) {
                         className="btn btn-sm btn-outline-primary w-100"
                         aria-label="Ouvrir les notifications"
                         title="Ouvrir les notifications"
-                        onClick={() => navigate('/notifications')}
+                        onClick={() => navigate(`/${lng}/notifications`)}
                       >
                         <i className="bi bi-bell"></i> {t('open_notifications')}
                       </button>
@@ -379,12 +382,12 @@ function Navbar({ sharedProps }) {
                     {userInfo ? (
                       <>
                         <li>
-                          <Link className="dropdown-item" to="/profile">
+                          <Link className="dropdown-item" to={`/${lng}/profile`}>
                             <i className="bi bi-person fs-5 me-2"></i> {t('profile')}
                           </Link>
                         </li>
                         <li>
-                          <Link className="dropdown-item" to="/settings">
+                          <Link className="dropdown-item" to={`/${lng}/settings`}>
                             <i className="bi bi-gear fs-5 me-2"></i> {t('settings.label')}
                           </Link>
                         </li>
@@ -406,13 +409,13 @@ function Navbar({ sharedProps }) {
                     ) : (
                       <>
                         <li>
-                          <Link className="dropdown-item" to="/login">
+                          <Link className="dropdown-item" to={`/${lng}/login`}>
                             <i className="bi bi-box-arrow-in-right fs-5 me-2"></i>{' '}
                             {t('login')}
                           </Link>
                         </li>
                         <li>
-                          <Link className="dropdown-item" to="/register">
+                          <Link className="dropdown-item" to={`/${lng}/register`}>
                             <i className="bi bi-person-plus fs-5 me-2"></i>{' '}
                             {t('register')}
                           </Link>
@@ -430,19 +433,19 @@ function Navbar({ sharedProps }) {
       <nav className="navbar fixed-bottom bg-white shadow-sm py-2 border-top border-2 d-lg-none">
         <div className="container-fluid d-flex justify-content-around mb-3">
           <Link
-            to="/calendars"
+            to={`/${lng}/calendars`}
             className="text-center text-dark text-decoration-none link-hover"
           >
             <i className="bi bi-calendar-event fs-1"></i>
           </Link>
           <Link
-            to="/shared-calendars"
+            to={`/${lng}/shared-calendars`}
             className="text-center text-dark text-decoration-none link-hover"
           >
             <i className="bi bi-people fs-1"></i>
           </Link>
           <Link
-            to="/notifications"
+            to={`/${lng}/notifications`}
             className="text-center text-dark text-decoration-none link-hover position-relative"
           >
             <i className="bi bi-bell fs-1"></i>
@@ -454,7 +457,7 @@ function Navbar({ sharedProps }) {
               )}
           </Link>
           <Link
-            to="/settings"
+            to={`/${lng}/settings`}
             className="text-center text-dark text-decoration-none link-hover"
           >
             {userInfo ? (

--- a/frontend/src/components/common/LanguageSelector.jsx
+++ b/frontend/src/components/common/LanguageSelector.jsx
@@ -2,9 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactFlagsSelect from 'react-flags-select';
 import { LANGUAGES } from '../../config/languages';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 
 function LanguageSelector() {
-  const { i18n, t  } = useTranslation();
+  const { i18n } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { lng } = useParams();
   const [selected, setSelected] = useState('FR');
 
   useEffect(() => {
@@ -15,6 +19,10 @@ function LanguageSelector() {
   const onSelect = (flagCode) => {
     const lang = LANGUAGES.find(lang => lang.flag === flagCode);
     if (lang) {
+      const segments = location.pathname.split('/');
+      segments[1] = lang.code;
+      const newPath = segments.join('/') || '/';
+      navigate(`${newPath}${location.search}${location.hash}`);
       i18n.changeLanguage(lang.code);
       setSelected(lang.flag);
     }

--- a/frontend/src/components/realtime/RealtimeManager.jsx
+++ b/frontend/src/components/realtime/RealtimeManager.jsx
@@ -30,8 +30,12 @@ export default function RealtimeManager({
     '/add-calendar',
   ];
 
+  // strip possible language prefix (e.g. /fr) before matching routes
+  const pathWithoutLang =
+    location.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+
   const isRealtimeEnabled = enabledRoutes.some((route) =>
-    location.pathname.startsWith(route)
+    pathWithoutLang.startsWith(route)
   );
 
   // ✅ Appel des hooks (OK car toujours dans un composant monté dans <Router>)

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './styles/index.css';
-import App from './App';
+import Root from './Root';
 import { UserProvider } from './contexts/UserContext';
 import './i18n';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <UserProvider>
-    <App />
+    <Root />
   </UserProvider>
 );

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -212,6 +212,10 @@
     "title3": "Safety assured"
   },
   "home": "Welcome",
+  "home_meta": {
+    "title": "MediTime - Medicine schedule planner",
+    "description": "Plan and share your medication schedules easily."
+  },
   "invalid_or_expired_link": "This shared calendar link is invalid or has expired.",
   "invitation": {
     "invalid_or_expired": "Invalid or expired invitation",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -212,6 +212,10 @@
     "title3": "Sécurité assurée"
   },
   "home": "Accueil",
+  "home_meta": {
+    "title": "MediTime - Planificateur de traitements",
+    "description": "Gérez et partagez facilement vos prises de médicaments."
+  },
   "invalid_or_expired_link": "Ce lien de calendrier partagé est invalide ou a expiré.",
   "invitation": {
     "invalid_or_expired": "Invitation invalide ou expirée",

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   GoogleHandleLogin,
   registerWithEmail,
@@ -34,9 +34,11 @@ function Auth() {
 
   const location = useLocation();
   const navigate = useNavigate();
+  const { lng } = useParams();
   const [redirect, setRedirect] = useState();
   useEffect(() => {
-    setActiveTab(location.pathname === '/register' ? 'register' : 'login');
+    const last = location.pathname.split('/').pop();
+    setActiveTab(last === 'register' ? 'register' : 'login');
     setRedirect(
       getValidRedirect(new URLSearchParams(location.search).get('redirect'))
     );
@@ -194,7 +196,10 @@ function Auth() {
                       user: userInfo.uid,
                     });
                     if (redirect) {
-                      navigate(redirect, { replace: true });
+                      navigate(
+                        redirect.startsWith('/') ? `/${lng}${redirect}` : redirect,
+                        { replace: true }
+                      );
                     }
                   }
                 } else {
@@ -294,7 +299,7 @@ function Auth() {
 
             {activeTab === 'login' && (
               <div className="mb-3 text-end">
-                <Link to="/reset-password" className="text-decoration-none">
+                <Link to={`/${lng}/reset-password`} className="text-decoration-none">
                   {t('auth.forgot_password')}
                 </Link>
               </div>
@@ -320,7 +325,7 @@ function Auth() {
                   htmlFor="terms"
                 >
                   {t('auth.accept_terms')}
-                  <Link to="/terms" className="text-decoration-none">
+                  <Link to={`/${lng}/terms`} className="text-decoration-none">
                     {t('auth.terms_link')}
                   </Link>
                 </label>

--- a/frontend/src/pages/auth/AuthCallback.jsx
+++ b/frontend/src/pages/auth/AuthCallback.jsx
@@ -1,6 +1,6 @@
 // src/pages/AuthCallback.jsx
 import { useEffect, useContext, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '../../services/supabase/supabaseClient';
 import { getGlobalReloadUser, UserContext } from '../../contexts/UserContext';
 import { log } from '../../utils/logger';
@@ -9,6 +9,7 @@ import { getValidRedirect } from '../../utils/redirect';
 
 const AuthCallback = () => {
   const navigate = useNavigate();
+  const { lng } = useParams();
   const reloadUser = getGlobalReloadUser();
   const { t } = useTranslation();
   const { userInfo } = useContext(UserContext);
@@ -48,7 +49,7 @@ const AuthCallback = () => {
           origin: 'CALLBACK_ERROR',
           uid: null,
         });
-        return navigate('/login', { replace: true });
+        return navigate(`/${lng}/login`, { replace: true });
       }
 
       const user = session.user;
@@ -73,11 +74,16 @@ const AuthCallback = () => {
     const type = typeRef.current;
 
     if (redirect) {
-      navigate(redirect, { replace: true });
+      if (redirect.startsWith('/')) {
+        const cleaned = redirect.replace(/^\/[a-z]{2}(?=\/|$)/, '');
+        navigate(`/${lng}${cleaned}`, { replace: true });
+      } else {
+        navigate(redirect, { replace: true });
+      }
       return;
     }
 
-    navigate(getRedirectPath(type), { replace: true });
+    navigate(`/${lng}${getRedirectPath(type)}`, { replace: true });
   }, [userInfo, navigate]);
 
   return <p>{t('auth_callback.loading')}</p>;

--- a/frontend/src/pages/auth/ResetPasswordConfirm.jsx
+++ b/frontend/src/pages/auth/ResetPasswordConfirm.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '../../services/supabase/supabaseClient';
 import AlertSystem from '../../components/common/AlertSystem';
 import { log } from '../../utils/logger';
@@ -12,6 +12,7 @@ export default function ResetPasswordConfirm() {
   const [loading, setLoading] = useState(false);
   const [sessionReady, setSessionReady] = useState(false);
   const navigate = useNavigate();
+  const { lng } = useParams();
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -59,7 +60,7 @@ export default function ResetPasswordConfirm() {
     } else {
       setAlertType('success');
       setAlertMessage(t('reset_password_confirm.success'));
-      setTimeout(() => navigate('/login'), 2500);
+      setTimeout(() => navigate(`/${lng}/login`), 2500);
     }
 
     setLoading(false);

--- a/frontend/src/pages/auth/VerifyEmail.jsx
+++ b/frontend/src/pages/auth/VerifyEmail.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { supabase } from '../../services/supabase/supabaseClient';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { UserContext, getGlobalReloadUser } from '../../contexts/UserContext';
 import AlertSystem from '../../components/common/AlertSystem';
 import { log } from '../../utils/logger';
@@ -17,6 +17,7 @@ function VerifyEmail() {
 
   // 📍 Navigation
   const navigate = useNavigate(); // Hook de navigation
+  const { lng } = useParams();
 
   useEffect(() => {
     if (userInfo?.emailVerified) {
@@ -25,7 +26,7 @@ function VerifyEmail() {
         origin: 'VerifyEmail.jsx',
         userInfo,
       });
-      navigate('/calendars');
+      navigate(`/${lng}/calendars`);
     }
   }, [userInfo, navigate]); // ✅ Si userInfo.emailVerified change, on redirige
 
@@ -38,7 +39,7 @@ function VerifyEmail() {
       try {
         await supabase.auth.sendEmailVerification({
           options: {
-            redirectTo: window.location.origin + '/auth/callback',
+            redirectTo: `${window.location.origin}/${lng}/auth/callback`,
           },
         });
         setAlertMessage(t('auth.verification_sent'));

--- a/frontend/src/pages/calendar/AcceptInvitePage.jsx
+++ b/frontend/src/pages/calendar/AcceptInvitePage.jsx
@@ -1,6 +1,6 @@
 // src/pages/AcceptInvitePage.jsx
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import HoveredUserProfile from '../../components/common/HoveredUserProfile';
 
@@ -13,6 +13,7 @@ function AcceptInvitePage({sharedUserCalendars}) {
   const [invitation, setInvitation] = useState(null);
 
   const navigate = useNavigate();
+  const { lng } = useParams();
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -52,13 +53,13 @@ function AcceptInvitePage({sharedUserCalendars}) {
       const rep = await sharedUserCalendars.acceptLoginInvitation(token);
       if (rep.success) {
         calendarId = rep.calendar_id;
-        navigate(`/shared-user-calendar/${calendarId}`);
+        navigate(`/${lng}/shared-user-calendar/${calendarId}`);
       }
     } else if (type === 'registration') {
       const rep = await sharedUserCalendars.acceptRegistrationInvitation(token);
       if (rep.success) {
         calendarId = rep.calendar_id;
-        navigate(`/shared-user-calendar/${calendarId}`);
+        navigate(`/${lng}/shared-user-calendar/${calendarId}`);
       }
     }
     setLoading(false);
@@ -69,12 +70,12 @@ function AcceptInvitePage({sharedUserCalendars}) {
     if (type === 'login') {
       const rep = await sharedUserCalendars.rejectLoginInvitation(token);
       if (rep.success) {
-        navigate('/calendars');
+        navigate(`/${lng}/calendars`);
       }
     } else if (type === 'registration') {
       const rep = await sharedUserCalendars.rejectRegistrationInvitation(token);
       if (rep.success) {
-        navigate('/calendars');
+        navigate(`/${lng}/calendars`);
       }
     }
     setLoading(false);

--- a/frontend/src/pages/calendar/AddCalendarPage.jsx
+++ b/frontend/src/pages/calendar/AddCalendarPage.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 function AddCalendarPage({ personalCalendars }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { lng } = useParams();
 
   const [newCalendarName, setNewCalendarName] = useState('');
   const [importType, setImportType] = useState('manual');
@@ -16,12 +17,12 @@ function AddCalendarPage({ personalCalendars }) {
     if (importType === 'manual') {
       const rep = await personalCalendars.addCalendar(newCalendarName);
       if (rep.success) {
-        navigate('/calendar/' + rep.calendarId + '/boxes');
+        navigate(`/${lng}/calendar/${rep.calendarId}/boxes`);
       } else {
         alert('❌ ' + rep.error);
       }
     } else if (importType === 'file') {
-      navigate('/add-calendar/import?name=' + encodeURIComponent(newCalendarName));
+      navigate(`/${lng}/add-calendar/import?name=${encodeURIComponent(newCalendarName)}`);
     }
   };
 

--- a/frontend/src/pages/calendar/CalendarList.jsx
+++ b/frontend/src/pages/calendar/CalendarList.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import AlertSystem from '../../components/common/AlertSystem';
 import HoveredUserProfile from '../../components/common/HoveredUserProfile';
 import ActionSheet from '../../components/common/ActionSheet';
@@ -11,6 +11,7 @@ function SelectCalendar({
   sharedUserCalendars
 }) {
   const navigate = useNavigate();
+  const { lng } = useParams();
   const { t } = useTranslation();
 
   // 📅 Gestion des calendriers
@@ -170,7 +171,7 @@ function SelectCalendar({
                       </span>
                     </div>
                     {calendarData.ifLowStock && (
-                      <button className="btn p-0" onClick={() => navigate(`/calendar/${calendarData.id}/stock-alerts`)}>
+                      <button className="btn p-0" onClick={() => navigate(`/${lng}/calendar/${calendarData.id}/stock-alerts`)}>
                         <span className="badge bg-warning d-flex align-items-center gap-1">
                           <i className='bi bi-exclamation-triangle-fill'></i>{t('stock_alert')}
                         </span>
@@ -183,7 +184,7 @@ function SelectCalendar({
                     className="btn btn-outline-success"
                     title={t('open')}
                     aria-label={t('open')}
-                    onClick={() => navigate('/calendar/' + calendarData.id)}
+                    onClick={() => navigate(`/${lng}/calendar/${calendarData.id}`)}
                   >
                     {t('open')}
                   </button>
@@ -206,7 +207,7 @@ function SelectCalendar({
                             <i className="bi bi-box-arrow-up me-2"></i> {t('share')}
                           </>
                         ),
-                        onClick: () => navigate(`/shared-calendars?calendar=${calendarData.id}`),
+                        onClick: () => navigate(`/${lng}/shared-calendars?calendar=${calendarData.id}`),
                       },
                       { separator: true },
                       {
@@ -215,7 +216,7 @@ function SelectCalendar({
                             <i className="bi bi-capsule me-2"></i> {t('medicines.label')}
                           </>
                         ),
-                        onClick: () => navigate(`/calendar/${calendarData.id}/boxes`),
+                        onClick: () => navigate(`/${lng}/calendar/${calendarData.id}/boxes`),
                       },
                       {
                         label: (
@@ -231,7 +232,8 @@ function SelectCalendar({
                             <i className="bi bi-exclamation-triangle-fill me-2"></i> {t('stock')}
                           </>
                         ),
-                        onClick: () => navigate(`/calendar/${calendarData.id}/stock-alerts`),
+                        onClick: () =>
+                          navigate(`/${lng}/calendar/${calendarData.id}/stock-alerts`),
                       },
                       { separator: true },
                       {
@@ -240,7 +242,8 @@ function SelectCalendar({
                             <i className="bi bi-gear me-2"></i> {t('settings.label')}
                           </>
                         ),
-                        onClick: () => navigate(`/calendar/${calendarData.id}/settings`),
+                        onClick: () =>
+                          navigate(`/${lng}/calendar/${calendarData.id}/settings`),
                       },
                       { separator: true },
                       {
@@ -308,7 +311,7 @@ function SelectCalendar({
 
             <button
               className="text-center btn btn-outline-primary rounded-0 rounded-bottom"
-              onClick={() => navigate('/add-calendar')}
+              onClick={() => navigate(`/${lng}/add-calendar`)}
             >
               <i className="bi bi-calendar-plus me-2"></i> {t('calendar.add_calendar')}
             </button>
@@ -387,7 +390,7 @@ function SelectCalendar({
                         />
                       </div>
                       {calendarData.ifLowStock && (
-                        <button className="btn p-0" onClick={() => navigate(`/shared-user-calendar/${calendarData.id}/stock-alerts`)}>
+                        <button className="btn p-0" onClick={() => navigate(`/${lng}/shared-user-calendar/${calendarData.id}/stock-alerts`)}>
                           <span className="badge bg-warning d-flex align-items-center gap-1">
                             <i className='bi bi-exclamation-triangle-fill'></i>{t('stock_alert')}
                           </span>
@@ -400,7 +403,7 @@ function SelectCalendar({
                       title={t('open')}
                       aria-label={t('open')}
                       onClick={() =>
-                        navigate('/shared-user-calendar/' + calendarData.id)
+                        navigate(`/${lng}/shared-user-calendar/${calendarData.id}`)
                       }
                     >
                       {t('open')}
@@ -414,7 +417,7 @@ function SelectCalendar({
                             </>
                           ),
                           onClick: () => {
-                            navigate(`/shared-user-calendar/${calendarData.id}/boxes`);
+                            navigate(`/${lng}/shared-user-calendar/${calendarData.id}/boxes`);
                           },
                         },
                         {
@@ -432,7 +435,7 @@ function SelectCalendar({
                             </>
                           ),
                           onClick: () => {
-                            navigate(`/shared-user-calendar/${calendarData.id}/stock-alerts`);
+                            navigate(`/${lng}/shared-user-calendar/${calendarData.id}/stock-alerts`);
                           },
                         },
                         { separator: true },
@@ -443,7 +446,7 @@ function SelectCalendar({
                             </>
                           ),
                           onClick: () => {
-                            navigate(`/shared-user-calendar/${calendarData.id}/settings`);
+                            navigate(`/${lng}/shared-user-calendar/${calendarData.id}/settings`);
                           },
                         },
                         { separator: true },

--- a/frontend/src/pages/calendar/CalendarSettingsPage.jsx
+++ b/frontend/src/pages/calendar/CalendarSettingsPage.jsx
@@ -13,6 +13,7 @@ function CalendarSettingsPage({
   const { t } = useTranslation();
   const location = useLocation();
   const params = useParams();
+  const { lng } = params;
 
   const sharedProps = {
     personalCalendars,
@@ -24,11 +25,14 @@ function CalendarSettingsPage({
   let calendarId = params.calendarId;
   let basePath = 'calendar';
 
-  if (location.pathname.startsWith('/shared-user-calendar')) {
+  const pathWithoutLang =
+    location.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+
+  if (pathWithoutLang.startsWith('/shared-user-calendar')) {
     calendarType = 'sharedUser';
     calendarId = params.calendarId;
     basePath = 'shared-user-calendar';
-  } else if (location.pathname.startsWith('/shared-token-calendar')) {
+  } else if (pathWithoutLang.startsWith('/shared-token-calendar')) {
     calendarType = 'token';
     calendarId = params.sharedToken;
     basePath = 'shared-token-calendar';
@@ -94,7 +98,7 @@ function CalendarSettingsPage({
                   <>
                     <Link
                       className={`nav-link text-start ${activeTab === 'stock' ? 'active' : ''}`}
-                      to={`/${basePath}/${calendarId}/settings?tab=stock`}
+                      to={`/${lng}/${basePath}/${calendarId}/settings?tab=stock`}
                     >
                       <i className="bi bi-capsule me-2"></i>
                       {t('calendar_settings.stock.label')}
@@ -106,7 +110,7 @@ function CalendarSettingsPage({
                   <>
                     <Link
                       className={`nav-link text-start ${activeTab === 'notifications' ? 'active' : ''}`}
-                      to={`/${basePath}/${calendarId}/settings?tab=notifications`}
+                      to={`/${lng}/${basePath}/${calendarId}/settings?tab=notifications`}
                     >
                       <i className="bi bi-bell me-2"></i>
                       {t('calendar_settings.notifications.label')}
@@ -117,7 +121,7 @@ function CalendarSettingsPage({
                 {/* 
                 <Link
                   className={`nav-link text-start ${activeTab === 'sharing' ? 'active' : ''}`}
-                  to={`/${basePath}/${calendarId}/settings?tab=sharing`}
+                  to={`/${lng}/${basePath}/${calendarId}/settings?tab=sharing`}
                 >
                   <i className="bi bi-share me-2"></i>
                   {t('calendar_settings.sharing.label')}

--- a/frontend/src/pages/calendar/CalendarView.jsx
+++ b/frontend/src/pages/calendar/CalendarView.jsx
@@ -26,6 +26,7 @@ function CalendarPage({
   const navigate = useNavigate(); // Hook de navigation
   const location = useLocation();
   const params = useParams();
+  const { lng } = params;
   const { t } = useTranslation();
 
   // 🔐 Contexte d'authentification
@@ -57,11 +58,14 @@ function CalendarPage({
   let calendarId = params.calendarId;
   let basePath = 'calendar';
 
-  if (location.pathname.startsWith('/shared-user-calendar')) {
+  const pathWithoutLang =
+    location.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+
+  if (pathWithoutLang.startsWith('/shared-user-calendar')) {
     calendarType = 'sharedUser';
     calendarId = params.calendarId;
     basePath = 'shared-user-calendar';
-  } else if (location.pathname.startsWith('/shared-token-calendar')) {
+  } else if (pathWithoutLang.startsWith('/shared-token-calendar')) {
     calendarType = 'token';
     calendarId = params.sharedToken;
     basePath = 'shared-token-calendar';
@@ -211,7 +215,7 @@ function CalendarPage({
                 {/* Bouton Médicaments qui prend tout l'espace dispo */}
                 <button
                   className="btn btn-outline-secondary flex-grow-1 me-auto"
-                  onClick={() => navigate(`/${basePath}/${calendarId}/boxes`)}
+                  onClick={() => navigate(`/${lng}/${basePath}/${calendarId}/boxes`)}
                   aria-label={t('medicines.label')}
                   title={t('medicines.label')}
                 >
@@ -229,7 +233,8 @@ function CalendarPage({
                             <i className="bi bi-box-arrow-up me-2" /> {t('share')}
                           </>
                         ),
-                        onClick: () => navigate(`/shared-calendars?calendar=${calendarId}`),
+                        onClick: () =>
+                          navigate(`/${lng}/shared-calendars?calendar=${calendarId}`),
                       },
                       { separator: true },
                       {
@@ -246,7 +251,8 @@ function CalendarPage({
                             <i className="bi bi-exclamation-triangle me-2" /> {t('stock')}
                           </>
                         ),
-                        onClick: () => navigate(`/${basePath}/${calendarId}/stock-alerts`),
+                        onClick: () =>
+                          navigate(`/${lng}/${basePath}/${calendarId}/stock-alerts`),
                       },
                       { separator: true },
                       {
@@ -255,7 +261,8 @@ function CalendarPage({
                             <i className="bi bi-gear me-2" /> {t('settings.label')}
                           </>
                         ),
-                        onClick: () => navigate(`/${basePath}/${calendarId}/settings`),
+                        onClick: () =>
+                          navigate(`/${lng}/${basePath}/${calendarId}/settings`),
                       },
                       { separator: true },
                       {
@@ -267,7 +274,7 @@ function CalendarPage({
                         onClick: async () => {
                           const rep = await personalCalendars.deleteCalendar(calendarId);
                           if (rep.success) {
-                            navigate('/calendars');
+                            navigate(`/${lng}/calendars`);
                           } else {
                             setAlertType('danger');
                             setAlertMessage(rep.error);
@@ -296,7 +303,8 @@ function CalendarPage({
                             <i className="bi bi-gear me-2" /> {t('settings.label')}
                           </>
                         ),
-                        onClick: () => navigate(`/${basePath}/${calendarId}/settings`),
+                        onClick: () =>
+                          navigate(`/${lng}/${basePath}/${calendarId}/settings`),
                       },
                       { separator: true },
                       {
@@ -317,7 +325,8 @@ function CalendarPage({
                 <button
                   type="button"
                   className="alert w-100 alert-warning d-flex align-items-center justify-content-between px-3 py-2 shadow"
-                  onClick={() => navigate(`/${basePath}/${calendarId}/stock-alerts`)}
+                  onClick={() =>
+                    navigate(`/${lng}/${basePath}/${calendarId}/stock-alerts`)}
                   title={t('stock_alert_tooltip')}
                   aria-label={t('stock_alert')}
                 >
@@ -361,7 +370,10 @@ function CalendarPage({
                   </h4>
                   <button
                     className="btn btn-outline-success w-100"
-                    onClick={() => navigate(`/${basePath}/${calendarId}/pillbox?date=${startDate}`)}
+                    onClick={() =>
+                      navigate(
+                        `/${lng}/${basePath}/${calendarId}/pillbox?date=${startDate}`
+                      )}
                   >
                     <i className="bi bi-capsule"></i> {t('pillbox.fill')}
                   </button>

--- a/frontend/src/pages/calendar/ImportCalendarPage.jsx
+++ b/frontend/src/pages/calendar/ImportCalendarPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import AlertSystem from '../../components/common/AlertSystem';
 
@@ -17,6 +17,7 @@ export default function ImportCalendarPage({ personalCalendars }) {
   const [alertType, setAlertType] = useState('');
 
   const navigate = useNavigate();
+  const { lng } = useParams();
 
   useEffect(() => {
     if (file) {
@@ -124,7 +125,7 @@ export default function ImportCalendarPage({ personalCalendars }) {
                         setAlertMessage(t('calendar.no_medicines_found'));
                         setAlertType('info');
                       }
-                      navigate('/add-calendar/review', {
+                      navigate(`/${lng}/add-calendar/review`, {
                         state: { importedMedicines: rep.medicines },
                       });
                     } else {

--- a/frontend/src/pages/calendar/Pillbox.jsx
+++ b/frontend/src/pages/calendar/Pillbox.jsx
@@ -7,15 +7,19 @@ import PillboxDisplay from '../../components/calendar/PillboxDisplay';
 function PillboxPage({ personalCalendars, sharedUserCalendars, tokenCalendars }) {
   const location = useLocation();
   const params = useParams();
+
   let calendarType = 'personal';
   let calendarId = params.calendarId;
   let basePath = 'calendar';
 
-  if (location.pathname.startsWith('/shared-user-calendar')) {
+  const pathWithoutLang =
+    location.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+
+  if (pathWithoutLang.startsWith('/shared-user-calendar')) {
     calendarType = 'sharedUser';
     calendarId = params.calendarId;
     basePath = 'shared-user-calendar';
-  } else if (location.pathname.startsWith('/shared-token-calendar')) {
+  } else if (pathWithoutLang.startsWith('/shared-token-calendar')) {
     calendarType = 'token';
     calendarId = params.sharedToken;
     basePath = 'shared-token-calendar';

--- a/frontend/src/pages/calendar/StockAlertsPage.jsx
+++ b/frontend/src/pages/calendar/StockAlertsPage.jsx
@@ -20,10 +20,13 @@ function StockAlertsPage({
   let calendarType = 'personal';
   let calendarId = params.calendarId;
 
-  if (location.pathname.startsWith('/shared-user-calendar')) {
+  const pathWithoutLang =
+    location.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+
+  if (pathWithoutLang.startsWith('/shared-user-calendar')) {
     calendarType = 'sharedUser';
     calendarId = params.calendarId;
-  } else if (location.pathname.startsWith('/shared-token-calendar')) {
+  } else if (pathWithoutLang.startsWith('/shared-token-calendar')) {
     calendarType = 'token';
     calendarId = params.sharedToken;
   }

--- a/frontend/src/pages/calendar/settings/Notifications.jsx
+++ b/frontend/src/pages/calendar/settings/Notifications.jsx
@@ -13,9 +13,12 @@ const Notifications = ({ personalCalendars, sharedUserCalendars, tokenCalendars 
   let calendarType = 'personal';
   let calendarId = params.calendarId;
 
-  if (location.pathname.startsWith('/shared-user-calendar')) {
+  const pathWithoutLang =
+    location.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+
+  if (pathWithoutLang.startsWith('/shared-user-calendar')) {
     calendarType = 'sharedUser';
-  } else if (location.pathname.startsWith('/shared-token-calendar')) {
+  } else if (pathWithoutLang.startsWith('/shared-token-calendar')) {
     calendarType = 'token';
     calendarId = params.sharedToken;
   }

--- a/frontend/src/pages/calendar/settings/Stock.jsx
+++ b/frontend/src/pages/calendar/settings/Stock.jsx
@@ -13,7 +13,10 @@ const Stock = ({ personalCalendars }) => {
   let calendarId = params.calendarId;
   let basePath = 'calendar';
 
-  if (location.pathname.startsWith('/shared-user-calendar')) {
+  const pathWithoutLang =
+    location.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+
+  if (pathWithoutLang.startsWith('/shared-user-calendar')) {
     calendarType = 'sharedUser';
     calendarId = params.calendarId;
     basePath = 'shared-user-calendar';

--- a/frontend/src/pages/general/HomePage.jsx
+++ b/frontend/src/pages/general/HomePage.jsx
@@ -1,21 +1,28 @@
 import React, { useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { UserContext } from '../../contexts/UserContext';
 import { useTranslation } from 'react-i18next';
+import Seo from '../../seo/Seo';
 
 function HomePage() {
   const navigate = useNavigate();
+  const { lng } = useParams();
   const { userInfo } = useContext(UserContext);
   const { t } = useTranslation();
   
-  const handleAccess = () => navigate('/calendars');
-  const handleLogin = () => navigate('/login');
-  const handleRegister = () => navigate('/register');
+  const handleAccess = () => navigate(`/${lng}/calendars`);
+  const handleLogin = () => navigate(`/${lng}/login`);
+  const handleRegister = () => navigate(`/${lng}/register`);
   const isIOS = /iphone|ipad|ipod/i.test(navigator.userAgent);
   const isAndroid = /android/i.test(navigator.userAgent);
 
   return (
     <>
+      <Seo
+        title={t('home_meta.title')}
+        description={t('home_meta.description')}
+        path="/home"
+      />
       <header className="hero hero bg-light border-bottom shadow-sm py-5 rounded-3">
         <div className="container text-center">
           <div className='d-flex align-items-center justify-content-center gap-1'>
@@ -160,14 +167,14 @@ function HomePage() {
       <section className="bg-white border-top py-4">
         <div className="container text-center">
           <a
-            href="/privacy"
+            href={`/${lng}/privacy`}
             className="text-muted text-decoration-none small me-3"
           >
             {t('privacy.label')}
           </a>
           <span className="text-muted small">|</span>
           <a
-            href="/terms"
+            href={`/${lng}/terms`}
             className="text-muted   text-decoration-none small ms-3"
           >
             {t('terms.label')}

--- a/frontend/src/pages/medicines/BoxesView.jsx
+++ b/frontend/src/pages/medicines/BoxesView.jsx
@@ -30,10 +30,13 @@ function BoxesView({ personalCalendars, sharedUserCalendars, tokenCalendars }) {
   let calendarType = 'personal';
   let calendarId = params.calendarId;
 
-  if (location.pathname.startsWith('/shared-user-calendar')) {
+  const pathWithoutLang =
+    location.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+
+  if (pathWithoutLang.startsWith('/shared-user-calendar')) {
     calendarType = 'sharedUser';
     calendarId = params.calendarId;
-  } else if (location.pathname.startsWith('/shared-token-calendar')) {
+  } else if (pathWithoutLang.startsWith('/shared-token-calendar')) {
     calendarType = 'token';
     calendarId = params.sharedToken;
   }

--- a/frontend/src/pages/notifications/NotificationsPage.jsx
+++ b/frontend/src/pages/notifications/NotificationsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import NotificationLine from '../../components/common/NotificationLine';
 import ActionSheet from '../../components/common/ActionSheet';
@@ -7,6 +7,7 @@ import ActionSheet from '../../components/common/ActionSheet';
 function NotificationsPage({ notifications, sharedUserCalendars }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { lng } = useParams();
 
   if (notifications.notificationsData === null) {
     return (
@@ -37,7 +38,7 @@ function NotificationsPage({ notifications, sharedUserCalendars }) {
                   <i className="bi bi-gear-fill me-2"></i> {t('settings.label')}
                 </>
               ),
-              onClick: () => navigate('/settings?tab=notifications'),
+              onClick: () => navigate(`/${lng}/settings?tab=notifications`),
             },
           ]}
         />

--- a/frontend/src/pages/settings/SettingsPage.jsx
+++ b/frontend/src/pages/settings/SettingsPage.jsx
@@ -3,7 +3,7 @@ import Security from './Security';
 import Notification from './Notification';
 import Account from './Account';
 import Preferences from './Preferences';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { handleLogout, resetPassword } from '../../services/auth/authService';
 import { UserContext } from '../../contexts/UserContext';
 import AlertSystem from '../../components/common/AlertSystem';
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 const SettingsPage = ({ sharedProps }) => {
   const { t } = useTranslation();
   const location = useLocation();
+  const { lng } = useParams();
   const { userInfo } = useContext(UserContext);
   const [alertType, setAlertType] = useState('');
   const [alertMessage, setAlertMessage] = useState('');
@@ -55,25 +56,25 @@ const SettingsPage = ({ sharedProps }) => {
               <div className="nav flex-column nav-pills">
                 <Link
                   className={`nav-link text-start ${activeTab === 'account' ? 'active' : ''}`}
-                  to="/settings?tab=account"
+                  to={`/${lng}/settings?tab=account`}
                 >
                   <i className="bi bi-person me-2"></i> {t('settings.account')}
                 </Link>
                 <Link
                   className={`nav-link text-start ${activeTab === 'security' ? 'active' : ''}`}
-                  to="/settings?tab=security"
+                  to={`/${lng}/settings?tab=security`}
                 >
                   <i className="bi bi-shield-lock me-2"></i> {t('settings.security')}
                 </Link>
                 <Link
                   className={`nav-link text-start ${activeTab === 'notifications' ? 'active' : ''}`}
-                  to="/settings?tab=notifications"
+                  to={`/${lng}/settings?tab=notifications`}
                 >
                   <i className="bi bi-bell me-2"></i> {t('notifications')}
                 </Link>
                 <Link
                   className={`nav-link text-start ${activeTab === 'preferences' ? 'active' : ''}`}
-                  to="/settings?tab=preferences"
+                  to={`/${lng}/settings?tab=preferences`}
                 >
                   <i className="bi bi-sliders me-2"></i> {t('settings.preferences')}
                 </Link>

--- a/frontend/src/pages/share/SharedList.jsx
+++ b/frontend/src/pages/share/SharedList.jsx
@@ -6,7 +6,7 @@ import HoveredUserProfile from "../../components/common/HoveredUserProfile";
 import { formatToLocalISODate } from "../../utils/calendar/dateUtils";
 import { useTranslation } from "react-i18next";
 import ActionSheet from '../../components/common/ActionSheet';
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate, useParams } from "react-router-dom";
 
 //TODO: changer l'affichage general pour simplifier les choses
 
@@ -23,6 +23,7 @@ function SharedList({
   const [searchParams, setSearchParams] = useSearchParams();
   const calendarFromURL = searchParams.get('calendar');
   const navigate = useNavigate(); // Hook pour la navigation
+  const { lng } = useParams();
 
   // ⚠️ Alertes et confirmations
   const [alertType, setAlertType] = useState(""); // Type d'alerte (ex. success, error)
@@ -49,7 +50,7 @@ function SharedList({
   const handleCopyLink = async (token) => {
     try {
       await navigator.clipboard.writeText(
-        `${VITE_URL}/shared-token-calendar/${token.id}`,
+        `${VITE_URL}/${lng}/shared-token-calendar/${token.id}`,
       );
       setAlertType("success");
       setAlertMessage(t("link_copied"));
@@ -373,7 +374,7 @@ const calendarActions = ({
           <i className="bi bi-eye me-2"></i> {t("open")}
         </>
       ),
-      onClick: () => navigate(`/calendar/${calendarId}`),
+      onClick: () => navigate(`/${lng}/calendar/${calendarId}`),
     },
     {
       label: (
@@ -381,7 +382,7 @@ const calendarActions = ({
           <i className="bi bi-capsule me-2"></i> {t("medicines.label")}
         </>
       ),
-      onClick: () => navigate(`/calendar/${calendarId}/boxes`),
+      onClick: () => navigate(`/${lng}/calendar/${calendarId}/boxes`),
     },
     { separator: true },
     {
@@ -400,7 +401,7 @@ const calendarActions = ({
             setAlertType("success");
             setAlertMessage("✅ " + rep.message);
             setTimeout(() => {
-              navigate("/calendars");
+              navigate(`/${lng}/calendars`);
             }, 1000);
           } else {
             setAlertType("danger");
@@ -562,7 +563,7 @@ function TokenList({
                   className={`form-control border-2 border-${token.revoked ? "danger" : "success"}`}
                   aria-label={t("shared_link_label")}
                   title={t("shared_link_label")}
-                  value={`${VITE_URL}/shared-token-calendar/${token.id}`}
+                  value={`${VITE_URL}/${lng}/shared-token-calendar/${token.id}`}
                   readOnly
                 />
                 <button

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, lazy, Suspense } from 'react';
-import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation, useParams } from 'react-router-dom';
 
 import { UserContext } from '../contexts/UserContext';
 
@@ -43,12 +43,13 @@ function buildFullPath(loc) {
 function PrivateRoute({ element }) {
   const { userInfo } = useContext(UserContext);
   const location = useLocation();
+  const { lng } = useParams();
 
   if (!userInfo) {
     const full = buildFullPath(location);
     return (
       <Navigate
-        to={`/login?redirect=${encodeURIComponent(full)}`}
+        to={`/${lng}/login?redirect=${encodeURIComponent(full)}`}
         replace
       />
     );
@@ -74,6 +75,7 @@ function RouteWithLoader({ element, isLoading }) {
 
 function AppRoutes({ sharedProps }) {
   const { userInfo } = useContext(UserContext);
+  const { lng } = useParams();
 
   const fallback = (
     <div
@@ -90,28 +92,28 @@ function AppRoutes({ sharedProps }) {
     <Suspense fallback={fallback}>
       <Routes>
       <Route
-        path="/login"
-        element={userInfo ? <Navigate to="/calendars" /> : <Auth />}
+        path="login"
+        element={userInfo ? <Navigate to={`/${lng}/calendars`} /> : <Auth />}
       />
       <Route
-        path="/register"
-        element={userInfo ? <Navigate to="/calendars" /> : <Auth />}
+        path="register"
+        element={userInfo ? <Navigate to={`/${lng}/calendars`} /> : <Auth />}
       />
       <Route
-        path="/reset-password"
+        path="reset-password"
         element={<ResetPassword />}
       />
       <Route
-        path="/reset-password-confirm"
+        path="reset-password-confirm"
         element={<ResetPasswordConfirm />}
       />
       <Route
-        path="/verify-email"
-        element={userInfo ? <VerifyEmail /> : <Navigate to="/login" />}
+        path="verify-email"
+        element={userInfo ? <VerifyEmail /> : <Navigate to={`/${lng}/login`} />}
       />
 
       <Route
-        path="/settings"
+        path="settings"
         element={
           <PrivateRoute
             element={
@@ -124,7 +126,7 @@ function AppRoutes({ sharedProps }) {
         }
       />
       <Route
-        path="/notifications"
+        path="notifications"
         element={
           <PrivateRoute
             element={
@@ -138,7 +140,7 @@ function AppRoutes({ sharedProps }) {
       />
 
       <Route
-        path="/shared-calendars"
+        path="shared-calendars"
         element={
           <PrivateRoute
             element={
@@ -150,7 +152,7 @@ function AppRoutes({ sharedProps }) {
           />
         }
       />
-      <Route path="/accept-invite">
+      <Route path="accept-invite">
         <Route
           index
           element={
@@ -160,7 +162,7 @@ function AppRoutes({ sharedProps }) {
           }
         />
       </Route>
-      <Route path="/add-calendar">
+      <Route path="add-calendar">
         <Route
           index
           element={
@@ -186,7 +188,7 @@ function AppRoutes({ sharedProps }) {
           }
         />
       </Route>
-      <Route path="/calendar/:calendarId">
+      <Route path="calendar/:calendarId">
         <Route
           index
           element={
@@ -254,7 +256,7 @@ function AppRoutes({ sharedProps }) {
         />
       </Route>
       <Route
-        path="/calendars"
+        path="calendars"
         element={
           <PrivateRoute
             element={
@@ -266,7 +268,7 @@ function AppRoutes({ sharedProps }) {
           />
         }
       />
-      <Route path="/shared-user-calendar/:calendarId">
+      <Route path="shared-user-calendar/:calendarId">
         <Route
           index
           element={
@@ -333,19 +335,19 @@ function AppRoutes({ sharedProps }) {
           }
         />
       </Route>
-      <Route path="/shared-token-calendar/:sharedToken">
+      <Route path="shared-token-calendar/:sharedToken">
         <Route index element={<CalendarView {...sharedProps} />} />
         <Route path="boxes" element={<MedicinesList {...sharedProps} />} />
         <Route path="pillbox" element={<PillboxPage {...sharedProps} />} />
       </Route>
 
-      <Route path="/privacy" element={<PrivacyPage />} />
-      <Route path="/terms" element={<TermsPage />} />
-      <Route path="/home" element={<HomePage />} />
+      <Route path="privacy" element={<PrivacyPage />} />
+      <Route path="terms" element={<TermsPage />} />
+      <Route path="home" element={<HomePage />} />
       <Route path="*" element={<NotFound />} />
-      <Route path="/" element={userInfo ? <Navigate to="/calendars" /> : <Navigate to="/home" />} />
+      <Route path="" element={userInfo ? <Navigate to={`/${lng}/calendars`} /> : <Navigate to={`/${lng}/home`} />} />
 
-      <Route path="/auth/callback" element={<AuthCallback />} />
+      <Route path="auth/callback" element={<AuthCallback />} />
       </Routes>
     </Suspense>
   );

--- a/frontend/src/seo/Seo.jsx
+++ b/frontend/src/seo/Seo.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LANGUAGES } from '../config/languages';
+
+const SITE_URL = import.meta.env.VITE_SITE_URL || 'https://meditime-app.com';
+
+function Seo({ title, description, path }) {
+  const { i18n } = useTranslation();
+  const lng = i18n.language;
+  const url = `${SITE_URL}/${lng}${path}`;
+  return (
+    <>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+      {LANGUAGES.map((lang) => (
+        <link
+          key={lang.code}
+          rel="alternate"
+          hrefLang={lang.code}
+          href={`${SITE_URL}/${lang.code}${path}`}
+        />
+      ))}
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={url} />
+      <meta property="og:type" content="website" />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+    </>
+  );
+}
+
+export default Seo;

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -8,9 +8,10 @@ import { getGlobalReloadUser } from '../../contexts/UserContext';
 const API_URL = import.meta.env.VITE_API_URL;
 
 function buildCallbackUrl(redirect) {
+  const lang = window.location.pathname.split('/')[1] || '';
   return (
     window.location.origin +
-    '/auth/callback' +
+    `/${lang}/auth/callback` +
     (redirect ? `?redirect=${encodeURIComponent(redirect)}` : '')
   );
 }
@@ -250,7 +251,7 @@ export const loginWithEmail = async (email, password, redirect) => {
 export const resetPassword = async (email) => {
   try {
     await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: window.location.origin + '/auth/callback',
+      redirectTo: buildCallbackUrl(),
     });
   } catch (error) {
     log.error(
@@ -271,7 +272,7 @@ export const handleLogout = async () => {
   try {
     await supabase.auth.signOut({
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(),
       },
     });
   } catch (error) {
@@ -290,7 +291,7 @@ export const updateUserPassword = async (newPassword) => {
     await supabase.auth.updateUser({
       password: newPassword,
       options: {
-        redirectTo: window.location.origin + '/auth/callback',
+        redirectTo: buildCallbackUrl(),
       },
     });
   } catch (error) {
@@ -334,7 +335,7 @@ export const loginWithMagicLink = async (email, redirect) => {
 export const inviteUserByEmail = async (email) => {
   try {
     const { error } = await supabase.auth.admin.inviteUserByEmail(email, {
-      redirectTo: window.location.origin + '/auth/callback',
+      redirectTo: buildCallbackUrl(),
     });
     if (error) {
       log.error("Erreur lors de l'invitation de l'utilisateur", error.message, {
@@ -360,7 +361,7 @@ export const updateUserEmail = async (newEmail) => {
     const { error } = await supabase.auth.updateUser({
       email: newEmail,
       options: {
-        emailRedirectTo: window.location.origin + '/auth/callback',
+        emailRedirectTo: buildCallbackUrl(),
       },
     });
     if (error) {
@@ -385,7 +386,7 @@ export const updateUserEmail = async (newEmail) => {
 export const reauthenticateUser = async () => {
   try {
     await supabase.auth.reauthenticate({
-      redirectTo: window.location.origin + '/auth/callback',
+      redirectTo: buildCallbackUrl(),
     });
   } catch (error) {
     log.error('Erreur lors de la réauthentification', error.message, {


### PR DESCRIPTION
## Summary
- add language-prefixed routing with automatic fallback
- update language selector to rewrite URLs and html `lang`
- provide SEO helper and localized metadata with sitemap variants
- strip language prefix when enabling realtime features
- fix redirect loop that repeatedly appended language prefixes
- normalize calendar path checks and language-aware navigation
- generate auth callback URLs and shared links with current locale
- handle private route and auth callback redirects with proper locale

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de2d606048328a61641fb56d5e7a9