### PR TITLE
refactor: centralize repeated messages and simplify verification helpers

### DIFF
--- a/backend/app/services/calendar/verification.py
+++ b/backend/app/services/calendar/verification.py
@@ -6,6 +6,30 @@ from app.db.connection import get_connection
 from app.utils.logging import log_backend as logger
 from app.utils.responses import warning_response
 
+ACCESS_DENIED_MSG = "accès refusé"
+
+
+def _extract_calendar_id(kwargs) -> str | None:
+    cal_id = kwargs.get("calendar_id")
+    if cal_id:
+        return cal_id
+    cal_id = getattr(request, "view_args", {}).get("calendar_id")
+    if cal_id:
+        return cal_id
+    if request.is_json:
+        body = request.get_json(silent=True) or {}
+        return body.get("calendarId") or body.get("calendar_id")
+    return None
+
+
+def _extract_token(kwargs) -> str | None:
+    return (
+        kwargs.get("token")
+        or getattr(request, "view_args", {}).get("token")
+        or request.args.get("token")
+    )
+
+
 def _verify_calendar_share(calendar_id: str, receiver_uid: str) -> bool:
     try:
         with get_connection() as conn:
@@ -28,7 +52,7 @@ def _verify_calendar_share(calendar_id: str, receiver_uid: str) -> bool:
 
                 # Partage absent pour ce receiver
                 if not row.get("share_exists"):
-                    logger.warning("accès refusé", {
+                    logger.warning(ACCESS_DENIED_MSG, {
                         "origin": "SHARED_VERIFY",
                         "uid": receiver_uid,
                         "calendar_id": calendar_id,
@@ -136,16 +160,11 @@ def verify_calendar_share(calendar_id=None, receiver_uid=None):
 
         @wraps(f)
         def wrapper(*args, **kwargs):
-            cal_id = kwargs.get("calendar_id")
-            if not cal_id and request.view_args:
-                cal_id = request.view_args.get("calendar_id")
-            if not cal_id and request.is_json:
-                body = request.get_json(silent=True) or {}
-                cal_id = body.get("calendarId") or body.get("calendar_id")
+            cal_id = _extract_calendar_id(kwargs)
             uid = kwargs.get("receiver_uid") or getattr(g, "uid", None)
             if not cal_id or not _verify_calendar_share(cal_id, uid):
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="SHARED_VERIFY_DENIED",
                     uid=uid,
                     origin="SHARED_VERIFY",
@@ -163,16 +182,11 @@ def verify_calendar(calendar_id=None, uid=None):
 
         @wraps(f)
         def wrapper(*args, **kwargs):
-            cal_id = kwargs.get("calendar_id")
-            if not cal_id and request.view_args:
-                cal_id = request.view_args.get("calendar_id")
-            if not cal_id and request.is_json:
-                body = request.get_json(silent=True) or {}
-                cal_id = body.get("calendarId") or body.get("calendar_id")
+            cal_id = _extract_calendar_id(kwargs)
             user_id = kwargs.get("uid") or getattr(g, "uid", None)
             if not cal_id or not _verify_calendar(cal_id, user_id):
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="CALENDAR_VERIFY_DENIED",
                     uid=user_id,
                     origin="CALENDAR_VERIFY",
@@ -190,11 +204,7 @@ def verify_token(token=None):
 
         @wraps(f)
         def wrapper(*args, **kwargs):
-            tok = (
-                kwargs.get("token")
-                or request.view_args.get("token") if request.view_args else None
-                or request.args.get("token")
-            )
+            tok = _extract_token(kwargs)
             calendar_id = _verify_token(tok)
             if not calendar_id:
                 return warning_response(
@@ -216,15 +226,11 @@ def verify_token_owner(token=None, uid=None):
 
         @wraps(f)
         def wrapper(*args, **kwargs):
-            tok = (
-                kwargs.get("token")
-                or request.view_args.get("token") if request.view_args else None
-                or request.args.get("token")
-            )
+            tok = _extract_token(kwargs)
             user_id = kwargs.get("uid") or getattr(g, "uid", None)
             if not tok or not _verify_token_owner(tok, user_id):
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="TOKEN_OWNER_VERIFY_DENIED",
                     uid=user_id,
                     origin="TOKEN_OWNER_VERIFY",
@@ -284,7 +290,7 @@ def verify_login_invitation_owner(token=None, uid=None):
             data = _verify_login_invite_owner(tok, user_id) if tok and user_id else False
             if not data:
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="LOGIN_INVITE_OWNER_VERIFY_DENIED",
                     uid=user_id,
                     origin="LOGIN_INVITE_OWNER_VERIFY",
@@ -350,7 +356,7 @@ def verify_registration_invitation_owner(token=None, uid=None):
             data = _verify_registration_invite_owner(tok, user_id) if tok and user_id else False
             if not data:
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="REG_INVITE_OWNER_VERIFY_DENIED",
                     uid=user_id,
                     origin="REG_INVITE_OWNER_VERIFY",
@@ -415,7 +421,7 @@ def verify_login_invitation_receiver(token=None, uid=None):
             data = _verify_login_invite_receiver(tok, user_id) if tok and user_id else False
             if not data:
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="LOGIN_INVITE_RECEIVER_VERIFY_DENIED",
                     uid=user_id,
                     origin="LOGIN_INVITE_RECEIVER_VERIFY",

--- a/backend/app/services/notifications/core.py
+++ b/backend/app/services/notifications/core.py
@@ -15,6 +15,8 @@ from html import escape
 # ========= Constantes =========
 ORIGIN = "NOTIFICATIONS"
 DEFAULT_CHANNELS: Tuple[str, ...] = ("push", "email", "web")
+DEFAULT_USER_NAME = "un utilisateur"
+VIEW_CALENDAR_LABEL = "Voir le calendrier"
 
 # ========= Types =========
 NotificationDict = Dict[str, Any]
@@ -23,9 +25,9 @@ NotificationDict = Dict[str, Any]
 # ========= Helpers de données =========
 def fetch_user_name(user_id: str | None) -> str:
     if not user_id:
-        return "un utilisateur"
+        return DEFAULT_USER_NAME
     user = fetch_user(user_id)
-    return user.get("display_name") if user else "un utilisateur"
+    return user.get("display_name") if user else DEFAULT_USER_NAME
 
 
 def fetch_calendar_name(calendar_id: str | None) -> str | None:
@@ -81,7 +83,7 @@ def _format_medication_list(medications: List[NotificationDict]) -> str:
     return "<ul style='margin:8px 0; padding-left:20px;'>" + "".join(lis) + "</ul>"
 
 def build_notification_text(notification_type: str, context: NotificationDict) -> Tuple[str, str, str]:
-    sender = _h(context.get("sender_name") or "un utilisateur")
+    sender = _h(context.get("sender_name") or DEFAULT_USER_NAME)
     cal = _h(context.get("calendar_name") or "ce calendrier")
 
     match notification_type:
@@ -103,12 +105,12 @@ def build_notification_text(notification_type: str, context: NotificationDict) -
         case "calendar_invitation_accepted":
             title = "✅ Invitation acceptée"
             body = _p(f"<b>{sender}</b> a accepté votre invitation pour « <b>{cal}</b> ».")
-            return (title, body, "Voir le calendrier")
+            return (title, body, VIEW_CALENDAR_LABEL)
 
         case "calendar_invitation_rejected":
             title = "❌ Invitation refusée"
             body = _p(f"<b>{sender}</b> a refusé votre invitation pour « <b>{cal}</b> ».")
-            return (title, body, "Voir le calendrier")
+            return (title, body, VIEW_CALENDAR_LABEL)
 
         case "calendar_shared_deleted_by_owner":
             title = "🔒 Partage annulé"
@@ -118,14 +120,14 @@ def build_notification_text(notification_type: str, context: NotificationDict) -
         case "calendar_shared_deleted_by_receiver":
             title = "📤 Partage retiré"
             body = _p(f"<b>{sender}</b> a retiré le calendrier « <b>{cal}</b> » de son compte.")
-            return (title, body, "Voir le calendrier")
+            return (title, body, VIEW_CALENDAR_LABEL)
 
         case "low_stock":
             title = f"⚠️ Stock faible – calendrier « {cal} »"
             if context.get("medications"):
                 body = _p(f"Certains médicaments du calendrier <b>« {cal} »</b> sont en stock critique :") \
                        + _format_medication_list(context["medications"])
-                return (title, body, "Voir le calendrier")
+                return (title, body, VIEW_CALENDAR_LABEL)
 
             med_name = _h(fetch_medicine_name(context.get("medication_id")))
             qty = context.get("medication_qty") or 0
@@ -134,7 +136,7 @@ def build_notification_text(notification_type: str, context: NotificationDict) -
             else:
                 stock_txt = f"<span style='color:orange;font-weight:bold;'>{qty} restant{'s' if qty != 1 else ''}</span>"
             body = _p(f"Le médicament <b>« {med_name} »</b> est {stock_txt}.")
-            return (title, body, "Voir le calendrier")
+            return (title, body, VIEW_CALENDAR_LABEL)
 
         case _:
             count = context.get("notification_count")


### PR DESCRIPTION
## Summary
- centralize repeated access denied message in calendar verification utilities
- extract default user and calendar action labels for notification helpers
- streamline calendar verification decorators with shared token/calendar ID extractors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a056aecf9c8328b1850758c39f0a70