### PR TITLE
refactor: simplify translation utilities and reduce frontend complexity

### DIFF
--- a/backend/app/services/calendar/verification.py
+++ b/backend/app/services/calendar/verification.py
@@ -6,6 +6,30 @@ from app.db.connection import get_connection
 from app.utils.logging import log_backend as logger
 from app.utils.responses import warning_response
 
+ACCESS_DENIED_MSG = "accès refusé"
+
+
+def _extract_calendar_id(kwargs) -> str | None:
+    cal_id = kwargs.get("calendar_id")
+    if cal_id:
+        return cal_id
+    cal_id = getattr(request, "view_args", {}).get("calendar_id")
+    if cal_id:
+        return cal_id
+    if request.is_json:
+        body = request.get_json(silent=True) or {}
+        return body.get("calendarId") or body.get("calendar_id")
+    return None
+
+
+def _extract_token(kwargs) -> str | None:
+    return (
+        kwargs.get("token")
+        or getattr(request, "view_args", {}).get("token")
+        or request.args.get("token")
+    )
+
+
 def _verify_calendar_share(calendar_id: str, receiver_uid: str) -> bool:
     try:
         with get_connection() as conn:
@@ -28,7 +52,7 @@ def _verify_calendar_share(calendar_id: str, receiver_uid: str) -> bool:
 
                 # Partage absent pour ce receiver
                 if not row.get("share_exists"):
-                    logger.warning("accès refusé", {
+                    logger.warning(ACCESS_DENIED_MSG, {
                         "origin": "SHARED_VERIFY",
                         "uid": receiver_uid,
                         "calendar_id": calendar_id,
@@ -136,16 +160,11 @@ def verify_calendar_share(calendar_id=None, receiver_uid=None):
 
         @wraps(f)
         def wrapper(*args, **kwargs):
-            cal_id = kwargs.get("calendar_id")
-            if not cal_id and request.view_args:
-                cal_id = request.view_args.get("calendar_id")
-            if not cal_id and request.is_json:
-                body = request.get_json(silent=True) or {}
-                cal_id = body.get("calendarId") or body.get("calendar_id")
+            cal_id = _extract_calendar_id(kwargs)
             uid = kwargs.get("receiver_uid") or getattr(g, "uid", None)
             if not cal_id or not _verify_calendar_share(cal_id, uid):
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="SHARED_VERIFY_DENIED",
                     uid=uid,
                     origin="SHARED_VERIFY",
@@ -163,16 +182,11 @@ def verify_calendar(calendar_id=None, uid=None):
 
         @wraps(f)
         def wrapper(*args, **kwargs):
-            cal_id = kwargs.get("calendar_id")
-            if not cal_id and request.view_args:
-                cal_id = request.view_args.get("calendar_id")
-            if not cal_id and request.is_json:
-                body = request.get_json(silent=True) or {}
-                cal_id = body.get("calendarId") or body.get("calendar_id")
+            cal_id = _extract_calendar_id(kwargs)
             user_id = kwargs.get("uid") or getattr(g, "uid", None)
             if not cal_id or not _verify_calendar(cal_id, user_id):
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="CALENDAR_VERIFY_DENIED",
                     uid=user_id,
                     origin="CALENDAR_VERIFY",
@@ -190,11 +204,7 @@ def verify_token(token=None):
 
         @wraps(f)
         def wrapper(*args, **kwargs):
-            tok = (
-                kwargs.get("token")
-                or request.view_args.get("token") if request.view_args else None
-                or request.args.get("token")
-            )
+            tok = _extract_token(kwargs)
             calendar_id = _verify_token(tok)
             if not calendar_id:
                 return warning_response(
@@ -216,15 +226,11 @@ def verify_token_owner(token=None, uid=None):
 
         @wraps(f)
         def wrapper(*args, **kwargs):
-            tok = (
-                kwargs.get("token")
-                or request.view_args.get("token") if request.view_args else None
-                or request.args.get("token")
-            )
+            tok = _extract_token(kwargs)
             user_id = kwargs.get("uid") or getattr(g, "uid", None)
             if not tok or not _verify_token_owner(tok, user_id):
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="TOKEN_OWNER_VERIFY_DENIED",
                     uid=user_id,
                     origin="TOKEN_OWNER_VERIFY",
@@ -284,7 +290,7 @@ def verify_login_invitation_owner(token=None, uid=None):
             data = _verify_login_invite_owner(tok, user_id) if tok and user_id else False
             if not data:
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="LOGIN_INVITE_OWNER_VERIFY_DENIED",
                     uid=user_id,
                     origin="LOGIN_INVITE_OWNER_VERIFY",
@@ -350,7 +356,7 @@ def verify_registration_invitation_owner(token=None, uid=None):
             data = _verify_registration_invite_owner(tok, user_id) if tok and user_id else False
             if not data:
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="REG_INVITE_OWNER_VERIFY_DENIED",
                     uid=user_id,
                     origin="REG_INVITE_OWNER_VERIFY",
@@ -415,7 +421,7 @@ def verify_login_invitation_receiver(token=None, uid=None):
             data = _verify_login_invite_receiver(tok, user_id) if tok and user_id else False
             if not data:
                 return warning_response(
-                    message="accès refusé",
+                    message=ACCESS_DENIED_MSG,
                     code="LOGIN_INVITE_RECEIVER_VERIFY_DENIED",
                     uid=user_id,
                     origin="LOGIN_INVITE_RECEIVER_VERIFY",

--- a/backend/app/services/notifications/core.py
+++ b/backend/app/services/notifications/core.py
@@ -15,6 +15,8 @@ from html import escape
 # ========= Constantes =========
 ORIGIN = "NOTIFICATIONS"
 DEFAULT_CHANNELS: Tuple[str, ...] = ("push", "email", "web")
+DEFAULT_USER_NAME = "un utilisateur"
+VIEW_CALENDAR_LABEL = "Voir le calendrier"
 
 # ========= Types =========
 NotificationDict = Dict[str, Any]
@@ -23,9 +25,9 @@ NotificationDict = Dict[str, Any]
 # ========= Helpers de données =========
 def fetch_user_name(user_id: str | None) -> str:
     if not user_id:
-        return "un utilisateur"
+        return DEFAULT_USER_NAME
     user = fetch_user(user_id)
-    return user.get("display_name") if user else "un utilisateur"
+    return user.get("display_name") if user else DEFAULT_USER_NAME
 
 
 def fetch_calendar_name(calendar_id: str | None) -> str | None:
@@ -81,7 +83,7 @@ def _format_medication_list(medications: List[NotificationDict]) -> str:
     return "<ul style='margin:8px 0; padding-left:20px;'>" + "".join(lis) + "</ul>"
 
 def build_notification_text(notification_type: str, context: NotificationDict) -> Tuple[str, str, str]:
-    sender = _h(context.get("sender_name") or "un utilisateur")
+    sender = _h(context.get("sender_name") or DEFAULT_USER_NAME)
     cal = _h(context.get("calendar_name") or "ce calendrier")
 
     match notification_type:
@@ -103,12 +105,12 @@ def build_notification_text(notification_type: str, context: NotificationDict) -
         case "calendar_invitation_accepted":
             title = "✅ Invitation acceptée"
             body = _p(f"<b>{sender}</b> a accepté votre invitation pour « <b>{cal}</b> ».")
-            return (title, body, "Voir le calendrier")
+            return (title, body, VIEW_CALENDAR_LABEL)
 
         case "calendar_invitation_rejected":
             title = "❌ Invitation refusée"
             body = _p(f"<b>{sender}</b> a refusé votre invitation pour « <b>{cal}</b> ».")
-            return (title, body, "Voir le calendrier")
+            return (title, body, VIEW_CALENDAR_LABEL)
 
         case "calendar_shared_deleted_by_owner":
             title = "🔒 Partage annulé"
@@ -118,14 +120,14 @@ def build_notification_text(notification_type: str, context: NotificationDict) -
         case "calendar_shared_deleted_by_receiver":
             title = "📤 Partage retiré"
             body = _p(f"<b>{sender}</b> a retiré le calendrier « <b>{cal}</b> » de son compte.")
-            return (title, body, "Voir le calendrier")
+            return (title, body, VIEW_CALENDAR_LABEL)
 
         case "low_stock":
             title = f"⚠️ Stock faible – calendrier « {cal} »"
             if context.get("medications"):
                 body = _p(f"Certains médicaments du calendrier <b>« {cal} »</b> sont en stock critique :") \
                        + _format_medication_list(context["medications"])
-                return (title, body, "Voir le calendrier")
+                return (title, body, VIEW_CALENDAR_LABEL)
 
             med_name = _h(fetch_medicine_name(context.get("medication_id")))
             qty = context.get("medication_qty") or 0
@@ -134,7 +136,7 @@ def build_notification_text(notification_type: str, context: NotificationDict) -
             else:
                 stock_txt = f"<span style='color:orange;font-weight:bold;'>{qty} restant{'s' if qty != 1 else ''}</span>"
             body = _p(f"Le médicament <b>« {med_name} »</b> est {stock_txt}.")
-            return (title, body, "Voir le calendrier")
+            return (title, body, VIEW_CALENDAR_LABEL)
 
         case _:
             count = context.get("notification_count")

--- a/frontend/scripts/convertFlatToNested.js
+++ b/frontend/scripts/convertFlatToNested.js
@@ -8,29 +8,32 @@ const SRC_DIR = path.join(__dirname, '../src');
 // 🔁 Conversion flat → nested avec transformation "key" → "key.label" si conflit
 function unflattenWithLabel(flatObj, keysToConvert) {
   const nestedObj = {};
-  for (const flatKey in flatObj) {
-    const keys = flatKey.split('.');
-    let current = nestedObj;
-
-    for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
-
-      if (i === keys.length - 1) {
-        if (keysToConvert.includes(keys[0]) && keys.length === 1) {
-          if (!current[key]) current[key] = {};
-          current[key]['label'] = flatObj[flatKey];
-        } else {
-          current[key] = flatObj[flatKey];
-        }
-      } else {
-        if (!current[key] || typeof current[key] !== 'object') {
-          current[key] = {};
-        }
-        current = current[key];
-      }
-    }
+  for (const [flatKey, value] of Object.entries(flatObj)) {
+    const targetKeys = buildTargetKeys(flatKey, keysToConvert);
+    assignValue(nestedObj, targetKeys, value);
   }
   return nestedObj;
+}
+
+function buildTargetKeys(flatKey, keysToConvert) {
+  const keys = flatKey.split('.');
+  if (keys.length === 1 && keysToConvert.includes(keys[0])) {
+    return [keys[0], 'label'];
+  }
+  return keys;
+}
+
+function assignValue(obj, keys, value) {
+  let current = obj;
+  keys.forEach((key, index) => {
+    if (index === keys.length - 1) {
+      current[key] = value;
+    } else {
+      current[key] =
+        typeof current[key] === 'object' && current[key] !== null ? current[key] : {};
+      current = current[key];
+    }
+  });
 }
 
 // 📂 Trouve les clés plates en conflit avec des sous-clés (ex: "settings" et "settings.account")

--- a/frontend/scripts/translate.js
+++ b/frontend/scripts/translate.js
@@ -100,135 +100,154 @@ async function translateObject(obj, targetLang) {
 // 🚀 Traitement principal
 (async () => {
   const source = loadJSON(sourceFile);
-
   for (const lang of LANGUAGES) {
-    const { code, locale } = lang;
-    if (code === 'fr') continue;
-
-    const outputFile = path.join(outputBase, code, 'translation.json');
-    let target = fs.existsSync(outputFile) ? loadJSON(outputFile) : {};
-
-    if (checkOnly) {
-      const missing = findMissingKeys(source, target);
-      if (missing.length > 0) {
-        console.log(`⛔ Clés manquantes pour ${code} (${locale}):`);
-        missing.forEach(k => console.log(`  - ${k}`));
-      } else {
-        console.log(`✅ ${code} : toutes les clés sont présentes.`);
-      }
-      continue;
-    }
-
-    if (localOnly) {
-      target.locale = locale;
-      saveJSON(outputFile, target);
-      console.log(`🔁 ${code} : locale mis à jour en "${locale}"`);
-      continue;
-    }
-
-    if (args.includes('--fill-missing')) {
-      const missing = findMissingKeys(source, target);
-      if (missing.length === 0) {
-        console.log(`✅ ${code} : aucune clé manquante.`);
-        continue;
-      }
-
-      console.log(`🧩 Remplissage des clés manquantes pour ${code}...`);
-      for (const fullKey of missing) {
-        const keys = fullKey.split('.');
-        let value = keys.reduce((obj, key) => obj?.[key], source);
-
-        if (value === undefined || value === null) {
-          console.warn(`⚠️  Clé introuvable dans fr: "${fullKey}"`);
-          continue;
-        }
-
-        // Cas : objet avec une seule clé string → traduit directement
-        if (
-          typeof value === 'object' &&
-          value !== null &&
-          Object.keys(value).length === 1 &&
-          typeof Object.values(value)[0] === 'string'
-        ) {
-          const onlyKey = Object.keys(value)[0];
-          const onlyVal = value[onlyKey];
-
-          try {
-            const [translated] = await translate.translate(onlyVal, code);
-            let ref = target;
-            while (keys.length > 1) {
-              const k = keys.shift();
-              ref[k] = ref[k] || {};
-              ref = ref[k];
-            }
-            ref[keys[0]] = { [onlyKey]: translated };
-            console.log(`✅ ${code} : "${fullKey}.${onlyKey}" → "${translated}"`);
-          } catch (e) {
-            console.error(`❌ Erreur de traduction pour ${fullKey}.${onlyKey} (${code}) : ${e.message}`);
-          }
-          continue;
-        }
-
-        // Cas : chaîne simple → traduit normalement
-        if (typeof value === 'string') {
-          try {
-            const protectedValue = protectPlaceholders(value);
-            const [translatedRaw] = await translate.translate(protectedValue, code);
-            const translated = restorePlaceholders(translatedRaw);
-            console.log(`✅ "${value}" → "${protectedValue}" → "${translated}"`);
-            
-            let ref = target;
-            while (keys.length > 1) {
-              const k = keys.shift();
-              ref[k] = ref[k] || {};
-              ref = ref[k];
-            }
-            ref[keys[0]] = translated;
-            console.log(`✅ ${code} : "${fullKey}" → "${translated}"`);
-          } catch (e) {
-            console.error(`❌ Erreur de traduction pour ${fullKey} (${code}) : ${e.message}`);
-          }
-          continue;
-        }
-
-        // Cas : objet complexe → traduction récursive
-        if (typeof value === 'object') {
-          try {
-            const translatedSubtree = await translateObject(value, code);
-            let ref = target;
-            while (keys.length > 1) {
-              const k = keys.shift();
-              ref[k] = ref[k] || {};
-              ref = ref[k];
-            }
-            ref[keys[0]] = translatedSubtree;
-            console.log(`✅ ${code} : "${fullKey}" → (sous-clés traduites)`);
-          } catch (e) {
-            console.error(`❌ Erreur de traduction récursive pour ${fullKey} (${code}) : ${e.message}`);
-          }
-          continue;
-        }
-
-        console.warn(`⚠️  Clé ignorée (type non pris en charge): "${fullKey}"`);
-      }
-
-      target.locale = locale;
-      saveJSON(outputFile, target);
-      console.log(`✅ ${code} : clés manquantes ajoutées.`);
-      continue;
-    }
-
-    if (!forceTranslate && fs.existsSync(outputFile)) {
-      console.log(`⏩ ${code} : fichier existant. Utilise --force ou --fill-missing.`);
-      continue;
-    }
-
-    console.log(`🌐 Traduction de 'fr' → '${code}'...`);
-    const translated = await translateObject(source, code);
-    translated.locale = locale;
-    saveJSON(outputFile, translated);
-    console.log(`✅ ${code} : traduction complète enregistrée.`);
+    await processLanguage(lang, source);
   }
-
   console.log('✨ Script terminé.');
 })();
+
+async function processLanguage(lang, source) {
+  const { code, locale } = lang;
+  if (code === 'fr') return;
+
+  const outputFile = path.join(outputBase, code, 'translation.json');
+  const target = fs.existsSync(outputFile) ? loadJSON(outputFile) : {};
+
+  if (checkOnly) return logMissing(source, target, code, locale);
+  if (localOnly) return updateLocale(target, outputFile, code, locale);
+  if (args.includes('--fill-missing'))
+    return await fillMissing(source, target, code, locale, outputFile);
+  if (!forceTranslate && fs.existsSync(outputFile)) {
+    console.log(`⏩ ${code} : fichier existant. Utilise --force ou --fill-missing.`);
+    return;
+  }
+  await translateAndSave(source, code, locale, outputFile);
+}
+
+function logMissing(source, target, code, locale) {
+  const missing = findMissingKeys(source, target);
+  if (missing.length > 0) {
+    console.log(`⛔ Clés manquantes pour ${code} (${locale}):`);
+    missing.forEach((k) => console.log(`  - ${k}`));
+  } else {
+    console.log(`✅ ${code} : toutes les clés sont présentes.`);
+  }
+}
+
+function updateLocale(target, outputFile, code, locale) {
+  target.locale = locale;
+  saveJSON(outputFile, target);
+  console.log(`🔁 ${code} : locale mis à jour en "${locale}"`);
+}
+
+async function fillMissing(source, target, code, locale, outputFile) {
+  const missing = findMissingKeys(source, target);
+  if (missing.length === 0) {
+    console.log(`✅ ${code} : aucune clé manquante.`);
+    return;
+  }
+
+  console.log(`🧩 Remplissage des clés manquantes pour ${code}...`);
+  for (const fullKey of missing) {
+    await translateMissingKey(fullKey, source, target, code);
+  }
+
+  target.locale = locale;
+  saveJSON(outputFile, target);
+  console.log(`✅ ${code} : clés manquantes ajoutées.`);
+}
+
+async function translateMissingKey(fullKey, source, target, code) {
+  const keys = fullKey.split('.');
+  const value = keys.reduce((obj, key) => obj?.[key], source);
+  if (value === undefined || value === null) {
+    console.warn(`⚠️  Clé introuvable dans fr: "${fullKey}"`);
+    return;
+  }
+  if (isSingleStringObject(value)) {
+    await translateSingleStringObject(value, keys, target, code, fullKey);
+    return;
+  }
+  if (typeof value === 'string') {
+    await translateSimpleString(value, keys, target, code, fullKey);
+    return;
+  }
+  if (typeof value === 'object') {
+    await translateComplexObject(value, keys, target, code, fullKey);
+    return;
+  }
+  console.warn(`⚠️  Clé ignorée (type non pris en charge): "${fullKey}"`);
+}
+
+function isSingleStringObject(value) {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.keys(value).length === 1 &&
+    typeof Object.values(value)[0] === 'string'
+  );
+}
+
+async function translateSingleStringObject(value, keys, target, code, fullKey) {
+  const onlyKey = Object.keys(value)[0];
+  const onlyVal = value[onlyKey];
+  try {
+    const [translated] = await translate.translate(onlyVal, code);
+    let ref = target;
+    while (keys.length > 1) {
+      const k = keys.shift();
+      ref[k] = ref[k] || {};
+      ref = ref[k];
+    }
+    ref[keys[0]] = { [onlyKey]: translated };
+    console.log(`✅ ${code} : "${fullKey}.${onlyKey}" → "${translated}"`);
+  } catch (e) {
+    console.error(
+      `❌ Erreur de traduction pour ${fullKey}.${onlyKey} (${code}) : ${e.message}`
+    );
+  }
+}
+
+async function translateSimpleString(value, keys, target, code, fullKey) {
+  try {
+    const protectedValue = protectPlaceholders(value);
+    const [translatedRaw] = await translate.translate(protectedValue, code);
+    const translated = restorePlaceholders(translatedRaw);
+    let ref = target;
+    while (keys.length > 1) {
+      const k = keys.shift();
+      ref[k] = ref[k] || {};
+      ref = ref[k];
+    }
+    ref[keys[0]] = translated;
+    console.log(`✅ ${code} : "${fullKey}" → "${translated}"`);
+  } catch (e) {
+    console.error(`❌ Erreur de traduction pour ${fullKey} (${code}) : ${e.message}`);
+  }
+}
+
+async function translateComplexObject(value, keys, target, code, fullKey) {
+  try {
+    const translatedSubtree = await translateObject(value, code);
+    let ref = target;
+    while (keys.length > 1) {
+      const k = keys.shift();
+      ref[k] = ref[k] || {};
+      ref = ref[k];
+    }
+    ref[keys[0]] = translatedSubtree;
+    console.log(`✅ ${code} : "${fullKey}" → (sous-clés traduites)`);
+  } catch (e) {
+    console.error(
+      `❌ Erreur de traduction récursive pour ${fullKey} (${code}) : ${e.message}`
+    );
+  }
+}
+
+async function translateAndSave(source, code, locale, outputFile) {
+  console.log(`🌐 Traduction de 'fr' → '${code}'...`);
+  const translated = await translateObject(source, code);
+  translated.locale = locale;
+  saveJSON(outputFile, translated);
+  console.log(`✅ ${code} : traduction complète enregistrée.`);
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,14 @@ import { getLocale } from './config/languages';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
+const fileToBase64 = (file) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result.split(',')[1]);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+
 function App() {
   const { t, i18n } = useTranslation();
   const { lng } = useParams();
@@ -651,25 +659,19 @@ function App() {
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  const analyzeImage = useCallback(async (file) => {
-    const fileToBase64 = (file) => new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result.split(',')[1]); // on retire le préfixe data:
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
-    const base64 = await fileToBase64(file);
+    const analyzeImage = useCallback(async (file) => {
+      const base64 = await fileToBase64(file);
 
-    return await performApiCall({
-      url: `${API_URL}/api/documents/analyze`,
-      method: 'POST',
-      body: { image: base64 },
-      origin: 'DOCUMENT_ANALYZE',
-      uid,
-      analyticsEvent: 'DOCUMENT_ANALYZE',
-      analyticsData: { uid },
-    });
-  }, []);
+      return await performApiCall({
+        url: `${API_URL}/api/documents/analyze`,
+        method: 'POST',
+        body: { image: base64 },
+        origin: 'DOCUMENT_ANALYZE',
+        uid,
+        analyticsEvent: 'DOCUMENT_ANALYZE',
+        analyticsData: { uid },
+      });
+    }, []);
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState, useRef } from 'react';
+import React, { useContext, useEffect, useState, useRef, useCallback } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { UserContext } from '../../contexts/UserContext';
 import { handleLogout } from '../../services/auth/authService';
@@ -9,53 +9,63 @@ import PropTypes from 'prop-types';
 import LanguageSelector from './LanguageSelector.jsx';
 import { useTranslation } from 'react-i18next';
 
+function buildLocationList(pathWithSlash) {
+  return {
+    calendar: pathWithSlash.startsWith('/calendar/'),
+    sharedUserCalendar: pathWithSlash.startsWith('/shared-user-calendar/'),
+    tokenCalendar: pathWithSlash.startsWith('/shared-token-calendar/'),
+  };
+}
+
+function buildReturnToCalendarList(pathParts) {
+  return {
+    calendar: pathParts.length === 2 && pathParts[0] === 'calendar',
+    sharedUserCalendar:
+      pathParts.length === 2 && pathParts[0] === 'shared-user-calendar',
+  };
+}
+
+function buildReturnToCalendar(pathParts) {
+  const isDetailPage =
+    pathParts.length === 3 &&
+    ['medicines', 'boxes', 'pillbox', 'settings', 'stock-alerts'].includes(
+      pathParts[2]
+    );
+  return {
+    calendar: pathParts[0] === 'calendar' && isDetailPage,
+    sharedUserCalendar:
+      pathParts[0] === 'shared-user-calendar' && isDetailPage,
+    tokenCalendar: pathParts.length === 3 && pathParts[0] === 'shared-token-calendar',
+  };
+}
+
+const isPillbox = (pathParts) =>
+  pathParts.length === 3 &&
+  ['calendar', 'shared-user-calendar', 'shared-token-calendar'].includes(
+    pathParts[0]
+  ) &&
+  pathParts[2] === 'pillbox';
+
 function Navbar({ sharedProps }) {
   const { userInfo } = useContext(UserContext);
   const navigate = useNavigate();
   const location = useLocation();
   const { lng } = useParams();
-  const { t } = useTranslation();
-  const [calendarInfo, setCalendarInfo] = useState(null);
-  const [basePath, setBasePath] = useState(null);
-  const [showNotifDropdown, setShowNotifDropdown] = useState(false);
-  const [showUserDropdown, setShowUserDropdown] = useState(false);
-  const notifRef = useRef();
-  const userRef = useRef();
-  const [tokenId, setTokenId] = useState(null);
-  const pathAfterLang = location.pathname.split('/').slice(2).join('/');
-  const pathWithSlash = '/' + pathAfterLang;
-  const locationList = {
-    calendar: pathWithSlash.startsWith('/calendar/'),
-    sharedUserCalendar: pathWithSlash.startsWith('/shared-user-calendar/'),
-    tokenCalendar: pathWithSlash.startsWith('/shared-token-calendar/'),
-  };
-
-  const pathParts = pathAfterLang.split('/').filter(Boolean);
-
-  const locationAvailableForReturnToCalendarList = {
-    calendar: 
-      pathParts.length === 2 && pathParts[0] === 'calendar',
-    sharedUserCalendar:
-      pathParts.length === 2 && pathParts[0] === 'shared-user-calendar',
-  };
-
-  const locationAvailableForReturnToCalendar = {
-    calendar:
-      pathParts.length === 3 &&
-      pathParts[0] === 'calendar' &&
-      (pathParts[2] === 'medicines' || pathParts[2] === 'boxes' || pathParts[2] === 'pillbox' || pathParts[2] === 'settings' || pathParts[2] === 'stock-alerts'),
-    sharedUserCalendar:
-      pathParts.length === 3 &&
-      pathParts[0] === 'shared-user-calendar' &&
-      (pathParts[2] === 'medicines' || pathParts[2] === 'boxes' || pathParts[2] === 'pillbox' || pathParts[2] === 'settings' || pathParts[2] === 'stock-alerts'),
-    tokenCalendar:
-      pathParts.length === 3 && pathParts[0] === 'shared-token-calendar',
-  };
-
-  const isPillboxPage =
-    pathParts.length === 3 &&
-    ['calendar', 'shared-user-calendar', 'shared-token-calendar'].includes(pathParts[0]) &&
-    pathParts[2] === 'pillbox';
+    const { t } = useTranslation();
+    const [calendarInfo, setCalendarInfo] = useState(null);
+    const [basePath, setBasePath] = useState(null);
+    const [showNotifDropdown, setShowNotifDropdown] = useState(false);
+    const [showUserDropdown, setShowUserDropdown] = useState(false);
+    const notifRef = useRef();
+    const userRef = useRef();
+    const [tokenId, setTokenId] = useState(null);
+    const pathAfterLang = location.pathname.split('/').slice(2).join('/');
+    const pathWithSlash = '/' + pathAfterLang;
+    const pathParts = pathAfterLang.split('/').filter(Boolean);
+    const locationList = buildLocationList(pathWithSlash);
+    const locationAvailableForReturnToCalendarList = buildReturnToCalendarList(pathParts);
+    const locationAvailableForReturnToCalendar = buildReturnToCalendar(pathParts);
+    const isPillboxPage = isPillbox(pathParts);
 
   useEffect(() => {
     if (locationList.calendar && sharedProps.personalCalendars.calendarsData) {
@@ -89,18 +99,19 @@ function Navbar({ sharedProps }) {
     sharedProps.sharedUserCalendars.sharedCalendarsData,
   ]);
 
-  useEffect(() => {
-    const handleClickOutside = (e) => {
+    const handleClickOutside = useCallback((e) => {
       if (notifRef.current && !notifRef.current.contains(e.target)) {
         setShowNotifDropdown(false);
       }
       if (userRef.current && !userRef.current.contains(e.target)) {
         setShowUserDropdown(false);
       }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+    }, []);
+
+    useEffect(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [handleClickOutside]);
 
   const { notificationsData, readNotification } = sharedProps.notifications;
 

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -48,6 +48,60 @@ function Auth() {
     if (tab !== activeTab) setActiveTab(tab);
   };
 
+  const handleLogin = async () => {
+    const error = await loginWithEmail(email, password, redirect);
+    if (error) {
+      setAlertMessage(
+        '❌ ' + t(`supabase-error.${error.code || 'unexpected_error'}`)
+      );
+      setAlertType('danger');
+      return;
+    }
+    log.info('Connexion réussie', {
+      id: 'LOGIN-SUCCESS',
+      origin: 'Auth.jsx',
+      user: userInfo.uid,
+    });
+    if (redirect) {
+      navigate(redirect.startsWith('/') ? `/${lng}${redirect}` : redirect, {
+        replace: true,
+      });
+    }
+  };
+
+  const handleRegister = async () => {
+    const error = await registerWithEmail(email, password, name, redirect);
+    if (error) {
+      setAlertMessage(
+        '❌ ' + t(`supabase-error.${error.code || 'unexpected_error'}`)
+      );
+      setAlertType('danger');
+      return;
+    }
+    log.info('Inscription réussie', {
+      id: 'REGISTER-SUCCESS',
+      origin: 'Auth.jsx',
+      user: userInfo.uid,
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      if (activeTab === 'login') {
+        await handleLogin();
+      } else {
+        await handleRegister();
+      }
+    } catch (err) {
+      log.error('Supabase auth error', {
+        id: 'AUTH-ERROR',
+        origin: 'Auth.jsx',
+        stack: err.stack,
+      });
+    }
+  };
+
   return (
     <div className="container d-flex justify-content-center align-items-center my-5">
       <div
@@ -180,50 +234,7 @@ function Auth() {
             duration={duration}
           />
 
-          <form
-            onSubmit={async (e) => {
-              e.preventDefault();
-              try {
-                if (activeTab === 'login') {
-                  const error = await loginWithEmail(email, password, redirect);
-                  if (error) {
-                    setAlertMessage('❌ ' + t(`supabase-error.${error.code || 'unexpected_error'}`));
-                    setAlertType('danger');
-                  } else {
-                    log.info('Connexion réussie', {
-                      id: 'LOGIN-SUCCESS',
-                      origin: 'Auth.jsx',
-                      user: userInfo.uid,
-                    });
-                    if (redirect) {
-                      navigate(
-                        redirect.startsWith('/') ? `/${lng}${redirect}` : redirect,
-                        { replace: true }
-                      );
-                    }
-                  }
-                } else {
-                  const error = await registerWithEmail(email, password, name, redirect);
-                  if (error) {
-                    setAlertMessage('❌ ' + t(`supabase-error.${error.code || 'unexpected_error'}`));
-                    setAlertType('danger');
-                  } else {
-                    log.info('Inscription réussie', {
-                      id: 'REGISTER-SUCCESS',
-                      origin: 'Auth.jsx',
-                      user: userInfo.uid,
-                    });
-                  }
-                }
-              } catch (err) {
-                log.error('Supabase auth error', {
-                  id: 'AUTH-ERROR',
-                  origin: 'Auth.jsx',
-                  stack: err.stack,
-                });
-              }
-            }}
-          >
+            <form onSubmit={handleSubmit}>
             {activeTab === 'register' && (
               <div className="mb-3">
                 <label htmlFor="name" className="form-label">

--- a/frontend/src/pages/medicines/BoxesView.jsx
+++ b/frontend/src/pages/medicines/BoxesView.jsx
@@ -8,6 +8,13 @@ import { fetchSuggestions } from '../../utils/api/fetchSuggestions';
 import ActionSheet from '../../components/common/ActionSheet';
 import { useTranslation } from 'react-i18next';
 
+const getBorderClass = (box) => {
+  if (box.box_capacity === 0) return '';
+  if (box.stock_quantity <= 0) return 'border-danger';
+  if (box.stock_quantity <= box.stock_alert_threshold) return 'border-warning';
+  return '';
+};
+
 function BoxesView({ personalCalendars, sharedUserCalendars, tokenCalendars }) {
   const location = useLocation();
   const params = useParams();
@@ -296,31 +303,26 @@ function BoxCard({
   dose,
 }) {
   const { t } = useTranslation();
-  const editable = selectedModifyBox === box.id;
-  const timeOfDayMap = {
-    morning: t('morning'),
-    noon: t('noon'),
-    evening: t('evening'),
-  };
+    const editable = selectedModifyBox === box.id;
+    const timeOfDayMap = {
+      morning: t('morning'),
+      noon: t('noon'),
+      evening: t('evening'),
+    };
 
-  const openNotice = (box_id) => {
-    const url = `${import.meta.env.VITE_API_URL}/api/proxy/pdf/${box_id}`;
-    window.open(url, '_blank');
-  };
+    const openNotice = (box_id) => {
+      const url = `${import.meta.env.VITE_API_URL}/api/proxy/pdf/${box_id}`;
+      window.open(url, '_blank');
+    };
 
-  return (
-    <div
-      className={`card h-100 shadow border ${
-        box.box_capacity === 0
-          ? ''
-          : box.stock_quantity <= 0
-            ? 'border-danger'
-            : box.stock_quantity <= box.stock_alert_threshold
-              ? 'border-warning'
-              : ''
-      }`}
-    >
-      <div className="card-body position-relative">
+    const toggleDrop = () =>
+      setSelectedDropBox((prev) => ({ ...prev, [box.id]: !prev[box.id] }));
+
+    const borderClass = getBorderClass(box);
+
+    return (
+      <div className={`card h-100 shadow border ${borderClass}`}>
+        <div className="card-body position-relative">
         <div className="position-absolute top-0 end-0 m-2">
           {(!selectedModifyBox || selectedModifyBox !== box.id) && (
             <ActionSheet
@@ -463,13 +465,7 @@ function BoxCard({
               type="button"
               title={t('boxes.intake_conditions')}
               aria-label={t('boxes.intake_conditions')}
-              onClick={() => {
-                if (selectedDropBox[box.id] === true) {
-                  setSelectedDropBox((prev) => ({ ...prev, [box.id]: false }));
-                } else {
-                  setSelectedDropBox((prev) => ({ ...prev, [box.id]: true }));
-                }
-              }}
+                onClick={toggleDrop}
             >
               <span>{t('boxes.intake_conditions')}</span>
               <i

--- a/frontend/src/pages/share/SharedList.jsx
+++ b/frontend/src/pages/share/SharedList.jsx
@@ -89,6 +89,34 @@ function SharedList({
     setSelectedModifyToken(null);
   };
 
+  const promptDeleteCalendar = ({
+    calendarId,
+    navigate,
+    personalCalendars,
+    setAlertType,
+    setAlertMessage,
+    setAlertId,
+    setOnConfirmAction,
+    t,
+    lng,
+  }) => {
+    setAlertType("confirm-danger");
+    setAlertMessage(t("delete_calendar_confirm"));
+    setAlertId(calendarId);
+    const onConfirm = async () => {
+      const rep = await personalCalendars.deleteCalendar(calendarId);
+      if (rep.success) {
+        setAlertType("success");
+        setAlertMessage("✅ " + rep.message);
+        setTimeout(() => navigate(`/${lng}/calendars`), 1000);
+      } else {
+        setAlertType("danger");
+        setAlertMessage("❌ " + rep.error);
+      }
+    };
+    setOnConfirmAction(() => onConfirm);
+  };
+
   // 🔄 Activation/désactivation du lien
   const handleToggleToken = async (tokenId) => {
     const rep = await tokenCalendars.updateRevokeToken(tokenId);
@@ -103,11 +131,23 @@ function SharedList({
     setSelectedModifyToken(null);
   };
 
+  const promptRegenerateToken = (tokenId, calendarId) => {
+    setAlertType("confirm-danger");
+    setAlertMessage(t("regenerate_link_confirm"));
+    setAlertId(tokenId);
+    const onConfirm = async () => {
+      await tokenCalendars.deleteToken(tokenId);
+      await handleCreateToken(calendarId);
+    };
+    setOnConfirmAction(() => onConfirm);
+  };
+
   const deleteTokenConfirmAction = (tokenId) => {
     setAlertType("confirm-danger");
     setAlertMessage(t("delete_link_confirm"));
     setAlertId(tokenId);
-    setOnConfirmAction(() => () => handleDeleteToken(tokenId));
+    const onConfirm = () => handleDeleteToken(tokenId);
+    setOnConfirmAction(() => onConfirm);
   };
 
   // 🔄 Suppression du lien
@@ -128,7 +168,8 @@ function SharedList({
     setAlertType("confirm-danger");
     setAlertMessage(t("delete_access_confirm"));
     setAlertId(token);
-    setOnConfirmAction(() => () => handleDeleteLoginInvitation(token));
+    const onConfirm = () => handleDeleteLoginInvitation(token);
+    setOnConfirmAction(() => onConfirm);
   };
 
   // 🔄 Suppression de l'utilisateur
@@ -152,7 +193,8 @@ function SharedList({
     setAlertType("confirm-danger");
     setAlertMessage(t("delete_link_confirm"));
     setAlertId(token);
-    setOnConfirmAction(() => () => handledeleteRegistrationInvitation(token));
+    const onConfirm = () => handledeleteRegistrationInvitation(token);
+    setOnConfirmAction(() => onConfirm);
   };
 
   const handledeleteRegistrationInvitation = async (token) => {
@@ -388,24 +430,18 @@ const calendarActions = ({
           <i className="bi bi-trash me-2"></i> {t("delete")}
         </>
       ),
-      onClick: () => {
-        setAlertType("confirm-danger");
-        setAlertMessage(t("delete_calendar_confirm"));
-        setAlertId(calendarId);
-        setOnConfirmAction(() => async () => {
-          const rep = await personalCalendars.deleteCalendar(calendarId);
-          if (rep.success) {
-            setAlertType("success");
-            setAlertMessage("✅ " + rep.message);
-            setTimeout(() => {
-              navigate(`/${lng}/calendars`);
-            }, 1000);
-          } else {
-            setAlertType("danger");
-            setAlertMessage("❌ " + rep.error);
-          }
-        });
-      },
+      onClick: () =>
+        promptDeleteCalendar({
+          calendarId,
+          navigate,
+          personalCalendars,
+          setAlertType,
+          setAlertMessage,
+          setAlertId,
+          setOnConfirmAction,
+          t,
+          lng,
+        }),
       danger: true,
     },
   ];
@@ -513,15 +549,7 @@ function TokenList({
                         <i className="bi bi-arrow-clockwise me-2"></i> {t('regenerate')}
                       </>
                     ),
-                    onClick: () => {
-                      setAlertType("confirm-danger");
-                      setAlertMessage(t("regenerate_link_confirm"));
-                      setAlertId(token.id);
-                      setOnConfirmAction(() => async () => {
-                        await tokenCalendars.deleteToken(token.id);
-                        await handleCreateToken(calendarId);
-                      });
-                    },
+                    onClick: () => promptRegenerateToken(token.id, calendarId),
                   },
                   { separator: true },
                   {


### PR DESCRIPTION
## Summary
- streamline flat-to-nested locale conversion with helper functions
- modularize translation script and extract calendar and token utilities
- reduce nested and complex logic in various frontend components
- flatten confirm-action handlers in SharedList to avoid deep nesting

## Testing
- `npm test` (fails: Missing script "test")
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a056aecf9c8328b1850758c39f0a70