### PR TITLE
Normalize language detection for invite URLs

### DIFF
--- a/frontend/src/Root.jsx
+++ b/frontend/src/Root.jsx
@@ -13,7 +13,11 @@ import { enabledLanguageCodes, LANGUAGES } from './config/languages';
 function LanguageRoutes() {
   const location = useLocation();
   const { i18n } = useTranslation();
-  const defaultLang = i18n.language || LANGUAGES[0].code;
+  const rawLang = i18n.language || LANGUAGES[0].code;
+  const normalizedLang = rawLang.split('-')[0];
+  const defaultLang = enabledLanguageCodes.includes(normalizedLang)
+    ? normalizedLang
+    : LANGUAGES[0].code;
   const pathParts = location.pathname.split('/');
   const currentLang = pathParts[1];
 


### PR DESCRIPTION
## Summary
- Ensure language routing falls back to a supported short code (e.g. `fr` instead of `fr-FR`)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `PYTHONPATH=backend python backend/app/main.py --check` *(fails: GOOGLE_APPLICATION_CREDENTIALS manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68a18d486404832883998a38d197344f