### PR TITLE
Expand multilingual SEO metadata and sitemap

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,12 +1,23 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
 
     <!-- ✅ META essentiels -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Application MediTime — gestion de prise de médicaments" />
+    <meta name="description" content="MediTime app — manage your medication schedules" />
+    <link rel="canonical" href="https://meditime-app.com/en/home" />
+    <link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/home" />
+    <link rel="alternate" hreflang="en" href="https://meditime-app.com/en/home" />
+    <link rel="alternate" hreflang="es" href="https://meditime-app.com/es/home" />
+    <link rel="alternate" hreflang="de" href="https://meditime-app.com/de/home" />
+    <link rel="alternate" hreflang="it" href="https://meditime-app.com/it/home" />
+    <link rel="alternate" hreflang="ja" href="https://meditime-app.com/ja/home" />
+    <link rel="alternate" hreflang="zh" href="https://meditime-app.com/zh/home" />
+    <link rel="alternate" hreflang="pt" href="https://meditime-app.com/pt/home" />
+    <link rel="alternate" hreflang="ru" href="https://meditime-app.com/ru/home" />
+    <link rel="alternate" hreflang="x-default" href="https://meditime-app.com/en/home" />
     <!--Android-->
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="application-name" content="MediTime" />
@@ -19,8 +30,17 @@
     <meta name="apple-mobile-web-app-title" content="MediTime" />
 
     <!-- ✅ Open Graph -->
-    <meta property="og:title" content="MediTime — Prise de médicaments simplifiée" />
-    <meta property="og:description" content="Planifiez vos traitements, recevez des rappels et partagez vos calendriers médicaux avec vos proches." />
+    <meta property="og:title" content="MediTime — Simplified medication tracking" />
+    <meta property="og:description" content="Plan your treatments, receive reminders and share your medical calendars with your loved ones." />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta property="og:locale:alternate" content="de_DE" />
+    <meta property="og:locale:alternate" content="it_IT" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:locale:alternate" content="zh_CN" />
+    <meta property="og:locale:alternate" content="pt_BR" />
+    <meta property="og:locale:alternate" content="ru_RU" />
     <meta property="og:image" content="https://meditime-app.com/icons/logo.webp" />
     <meta property="og:url" content="https://meditime-app.com" />
     <meta property="og:type" content="website" />

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -6,6 +6,13 @@
     <loc>https://meditime-app.com/fr/home</loc>
     <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/home" />
     <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/home" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://meditime-app.com/es/home" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://meditime-app.com/de/home" />
+    <xhtml:link rel="alternate" hreflang="it" href="https://meditime-app.com/it/home" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://meditime-app.com/ja/home" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://meditime-app.com/zh/home" />
+    <xhtml:link rel="alternate" hreflang="pt" href="https://meditime-app.com/pt/home" />
+    <xhtml:link rel="alternate" hreflang="ru" href="https://meditime-app.com/ru/home" />
     <priority>1.0</priority>
   </url>
 
@@ -13,6 +20,13 @@
     <loc>https://meditime-app.com/fr/login</loc>
     <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/login" />
     <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/login" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://meditime-app.com/es/login" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://meditime-app.com/de/login" />
+    <xhtml:link rel="alternate" hreflang="it" href="https://meditime-app.com/it/login" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://meditime-app.com/ja/login" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://meditime-app.com/zh/login" />
+    <xhtml:link rel="alternate" hreflang="pt" href="https://meditime-app.com/pt/login" />
+    <xhtml:link rel="alternate" hreflang="ru" href="https://meditime-app.com/ru/login" />
     <priority>0.8</priority>
   </url>
 
@@ -20,6 +34,13 @@
     <loc>https://meditime-app.com/fr/register</loc>
     <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/register" />
     <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/register" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://meditime-app.com/es/register" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://meditime-app.com/de/register" />
+    <xhtml:link rel="alternate" hreflang="it" href="https://meditime-app.com/it/register" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://meditime-app.com/ja/register" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://meditime-app.com/zh/register" />
+    <xhtml:link rel="alternate" hreflang="pt" href="https://meditime-app.com/pt/register" />
+    <xhtml:link rel="alternate" hreflang="ru" href="https://meditime-app.com/ru/register" />
     <priority>0.8</priority>
   </url>
 
@@ -27,6 +48,13 @@
     <loc>https://meditime-app.com/fr/reset-password</loc>
     <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/reset-password" />
     <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/reset-password" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://meditime-app.com/es/reset-password" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://meditime-app.com/de/reset-password" />
+    <xhtml:link rel="alternate" hreflang="it" href="https://meditime-app.com/it/reset-password" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://meditime-app.com/ja/reset-password" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://meditime-app.com/zh/reset-password" />
+    <xhtml:link rel="alternate" hreflang="pt" href="https://meditime-app.com/pt/reset-password" />
+    <xhtml:link rel="alternate" hreflang="ru" href="https://meditime-app.com/ru/reset-password" />
     <priority>0.5</priority>
   </url>
 
@@ -34,6 +62,13 @@
     <loc>https://meditime-app.com/fr/reset-password-confirm</loc>
     <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/reset-password-confirm" />
     <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/reset-password-confirm" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://meditime-app.com/es/reset-password-confirm" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://meditime-app.com/de/reset-password-confirm" />
+    <xhtml:link rel="alternate" hreflang="it" href="https://meditime-app.com/it/reset-password-confirm" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://meditime-app.com/ja/reset-password-confirm" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://meditime-app.com/zh/reset-password-confirm" />
+    <xhtml:link rel="alternate" hreflang="pt" href="https://meditime-app.com/pt/reset-password-confirm" />
+    <xhtml:link rel="alternate" hreflang="ru" href="https://meditime-app.com/ru/reset-password-confirm" />
     <priority>0.5</priority>
   </url>
 
@@ -41,6 +76,13 @@
     <loc>https://meditime-app.com/fr/verify-email</loc>
     <xhtml:link rel="alternate" hreflang="fr" href="https://meditime-app.com/fr/verify-email" />
     <xhtml:link rel="alternate" hreflang="en" href="https://meditime-app.com/en/verify-email" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://meditime-app.com/es/verify-email" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://meditime-app.com/de/verify-email" />
+    <xhtml:link rel="alternate" hreflang="it" href="https://meditime-app.com/it/verify-email" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://meditime-app.com/ja/verify-email" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://meditime-app.com/zh/verify-email" />
+    <xhtml:link rel="alternate" hreflang="pt" href="https://meditime-app.com/pt/verify-email" />
+    <xhtml:link rel="alternate" hreflang="ru" href="https://meditime-app.com/ru/verify-email" />
     <priority>0.5</priority>
   </url>
 

--- a/frontend/src/seo/Seo.jsx
+++ b/frontend/src/seo/Seo.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LANGUAGES } from '../config/languages';
+import { LANGUAGES, getLocale } from '../config/languages';
 
 const SITE_URL = import.meta.env.VITE_SITE_URL || 'https://meditime-app.com';
 
@@ -8,6 +8,10 @@ function Seo({ title, description, path }) {
   const { i18n } = useTranslation();
   const lng = i18n.language;
   const url = `${SITE_URL}/${lng}${path}`;
+
+  useEffect(() => {
+    document.documentElement.lang = lng;
+  }, [lng]);
   return (
     <>
       <title>{title}</title>
@@ -19,6 +23,14 @@ function Seo({ title, description, path }) {
           rel="alternate"
           hrefLang={lang.code}
           href={`${SITE_URL}/${lang.code}${path}`}
+        />
+      ))}
+      <meta property="og:locale" content={getLocale(lng)} />
+      {LANGUAGES.filter((lang) => lang.code !== lng).map((lang) => (
+        <meta
+          key={lang.code}
+          property="og:locale:alternate"
+          content={lang.locale}
         />
       ))}
       <meta property="og:title" content={title} />


### PR DESCRIPTION
## Summary
- include all available languages in sitemap
- update Seo component to set html lang and Open Graph locale metadata
- add canonical and alternate links plus locale meta tags in index.html

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1fe7f84888328937265fcb452aea3