### PR TITLE
Use language codes directly in SEO metadata

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,6 @@ import RealtimeManager from './components/realtime/RealtimeManager';
 import { getToken } from './services/supabase/tokenUtils';
 import { performApiCall } from './services/api/apiUtils';
 import { useTranslation } from 'react-i18next';
-import { getLocale } from './config/languages';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -836,7 +835,7 @@ function App() {
     if (lng && i18n.language !== lng) {
       i18n.changeLanguage(lng);
     }
-    document.documentElement.setAttribute('lang', getLocale(lng));
+    document.documentElement.setAttribute('lang', lng);
   }, [lng, i18n]);
 
   return (

--- a/frontend/src/config/languages.js
+++ b/frontend/src/config/languages.js
@@ -1,19 +1,19 @@
 export const LANGUAGES = [
-  { flag: 'FR', code: 'fr', locale: 'fr_FR', label: 'Français' },
-  { flag: 'US', code: 'en', locale: 'en_US', label: 'English' },
-  { flag: 'ES', code: 'es', locale: 'es_ES', label: 'Español' },
-  { flag: 'DE', code: 'de', locale: 'de_DE', label: 'Deutsch' },
-  { flag: 'IT', code: 'it', locale: 'it_IT', label: 'Italiano' },
-  { flag: 'JP', code: 'ja', locale: 'ja_JP', label: '日本語' },
-  { flag: 'CN', code: 'zh', locale: 'zh_CN', label: '中文' },
-  { flag: 'PT', code: 'pt', locale: 'pt_BR', label: 'Português' },
-  { flag: 'RU', code: 'ru', locale: 'ru_RU', label: 'Русский' }
+  { flag: 'FR', code: 'fr', locale: 'fr-FR', label: 'Français' },
+  { flag: 'US', code: 'en', locale: 'en-US', label: 'English' },
+  { flag: 'ES', code: 'es', locale: 'es-ES', label: 'Español' },
+  { flag: 'DE', code: 'de', locale: 'de-DE', label: 'Deutsch' },
+  { flag: 'IT', code: 'it', locale: 'it-IT', label: 'Italiano' },
+  { flag: 'JP', code: 'ja', locale: 'ja-JP', label: '日本語' },
+  { flag: 'CN', code: 'zh', locale: 'zh-CN', label: '中文' },
+  { flag: 'PT', code: 'pt', locale: 'pt-BR', label: 'Português' },
+  { flag: 'RU', code: 'ru', locale: 'ru-RU', label: 'Русский' }
 ];
 
-export const DEFAULT_LANG = 'en_US';
+export const DEFAULT_LANG = 'en';
 
 export const getLocale = (code) => {
-  return LANGUAGES.find((lang) => lang.code === code)?.locale || code.replace('-', '_');
+  return LANGUAGES.find((lang) => lang.code === code)?.locale || code;
 };
 
 export const getLabel = (code) => {

--- a/frontend/src/seo/Seo.jsx
+++ b/frontend/src/seo/Seo.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LANGUAGES, getLocale, DEFAULT_LANG } from '../config/languages';
+import { LANGUAGES, DEFAULT_LANG } from '../config/languages';
 
 
 const VITE_URL = import.meta.env.VITE_VITE_URL;
@@ -42,10 +42,10 @@ function Seo({ title, description, path }) {
       href: `${VITE_URL}/${DEFAULT_LANG}${path}`,
     });
 
-    upsertTag('meta', 'property', 'og:locale', { content: getLocale(lng) });
+    upsertTag('meta', 'property', 'og:locale', { content: lng });
     LANGUAGES.filter((lang) => lang.code !== lng).forEach((lang) => {
       upsertTag('meta', 'property', 'og:locale:alternate', {
-        content: lang.locale,
+        content: lang.code,
       });
     });
     upsertTag('meta', 'property', 'og:site_name', { content: 'MediTime' });


### PR DESCRIPTION
## Summary
- Remove locale conversion in SEO and rely on active language codes for `<html>`, canonical, and OpenGraph tags
- Generate alternate locale links and `og:locale` values using simple language codes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2279bcb108328ab2d547200c1c248