### PR TITLE
chore: guard auth logs against missing user

### DIFF
--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -60,7 +60,7 @@ function Auth() {
     log.info('Connexion réussie', {
       id: 'LOGIN-SUCCESS',
       origin: 'Auth.jsx',
-      user: userInfo.uid,
+      user: userInfo?.uid,
     });
     if (redirect) {
       navigate(redirect.startsWith('/') ? `/${lng}${redirect}` : redirect, {
@@ -81,7 +81,7 @@ function Auth() {
     log.info('Inscription réussie', {
       id: 'REGISTER-SUCCESS',
       origin: 'Auth.jsx',
-      user: userInfo.uid,
+      user: userInfo?.uid,
     });
   };
 


### PR DESCRIPTION
## Summary
- guard auth success log statements against missing `userInfo`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `node` (simulate login/register logging with undefined `userInfo`)

------
https://chatgpt.com/codex/tasks/task_e_68a36026ecd0832890fffe69ce6324ed