### PR TITLE
Gracefully handle empty calendars

### DIFF
--- a/backend/app/routes/personnal_calendar.py
+++ b/backend/app/routes/personnal_calendar.py
@@ -37,10 +37,10 @@ def handle_calendars():
                 calendars = cursor.fetchall()
 
                 if not calendars:
-                    return warning_response(
-                        message=ERROR_CALENDAR_NOT_FOUND, 
-                        code="CALENDAR_FETCH_ERROR", 
-                        status_code=404
+                    return success_response(
+                        message="calendriers récupérés",
+                        code="CALENDAR_FETCH_SUCCESS",
+                        data={"calendars": []},
                     )
 
                 for calendar in calendars:
@@ -48,8 +48,8 @@ def handle_calendars():
                     calendar["ifLowStock"] = check_if_stock_is_low(calendar["id"])
 
         return success_response(
-            message="calendriers récupérés", 
-            code="CALENDAR_FETCH_SUCCESS", 
+            message="calendriers récupérés",
+            code="CALENDAR_FETCH_SUCCESS",
             data={"calendars": calendars},
         )
     except Exception as e:

--- a/frontend/src/hooks/realtime/useRealtimeCalendars.js
+++ b/frontend/src/hooks/realtime/useRealtimeCalendars.js
@@ -20,12 +20,13 @@ const fetchCalendars = async (uid, setCalendarsData, setLoadingStates) => {
     });
 
     const data = await res.json();
-    if (!res.ok) throw new Error(data.error);
+    if (!res.ok && res.status !== 404) throw new Error(data.error);
 
-    const sortedCalendars = data.calendars.sort((a, b) =>
+    const calendars = (data.calendars || []).sort((a, b) =>
       a.name.localeCompare(b.name)
     );
-    setCalendarsData(sortedCalendars);
+
+    setCalendarsData(calendars);
     setLoadingStates((prev) => ({ ...prev, calendars: false }));
 
     const [{ analyticsPromise }, { logEvent }] = await Promise.all([
@@ -36,7 +37,7 @@ const fetchCalendars = async (uid, setCalendarsData, setLoadingStates) => {
       if (analytics) {
         logEvent(analytics, 'fetch_calendars', {
           uid,
-          count: data.calendars?.length,
+          count: calendars.length,
         });
       }
     });
@@ -44,8 +45,10 @@ const fetchCalendars = async (uid, setCalendarsData, setLoadingStates) => {
     log.info(data.message, {
       origin: 'REALTIME_CALENDAR_FETCH',
       uid,
-      code: 'REALTIME_CALENDAR_FETCH_SUCCESS',
-      count: data.calendars?.length,
+      code: calendars.length
+        ? 'REALTIME_CALENDAR_FETCH_SUCCESS'
+        : 'REALTIME_CALENDAR_FETCH_EMPTY',
+      count: calendars.length,
     });
   } catch (err) {
     setLoadingStates((prev) => ({ ...prev, calendars: false }));


### PR DESCRIPTION
## Summary
- Treat missing personal calendars as a successful empty response in backend
- Handle empty calendar lists in realtime hook without throwing and log info

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a36af6c87083289b2e473376b06c88