### PR TITLE
Redirect to auth callback after password login

### DIFF
--- a/frontend/src/contexts/UserContext.jsx
+++ b/frontend/src/contexts/UserContext.jsx
@@ -105,14 +105,10 @@ export const UserProvider = ({ children }) => {
   useEffect(() => {
     const { data: listener } = supabase.auth.onAuthStateChange(
       (event, session) => {
-        if ((event === 'TOKEN_REFRESHED' || event === 'SIGNED_IN') && session) {
+        if (event === 'TOKEN_REFRESHED' && session) {
           if (tokenRef.current !== session.access_token) {
             tokenRef.current = session.access_token;
-            const msg =
-              event === 'SIGNED_IN'
-                ? '[UserContext] Connexion détectée, appel reloadUser'
-                : '[UserContext] Token mis à jour, appel reloadUser';
-            log.info(msg);
+            log.info('[UserContext] Token mis à jour, appel reloadUser');
             reloadUser();
           }
         } else if (event === 'SIGNED_OUT') {

--- a/frontend/src/contexts/UserContext.jsx
+++ b/frontend/src/contexts/UserContext.jsx
@@ -105,10 +105,14 @@ export const UserProvider = ({ children }) => {
   useEffect(() => {
     const { data: listener } = supabase.auth.onAuthStateChange(
       (event, session) => {
-        if (event === 'TOKEN_REFRESHED' && session) {
+        if ((event === 'TOKEN_REFRESHED' || event === 'SIGNED_IN') && session) {
           if (tokenRef.current !== session.access_token) {
             tokenRef.current = session.access_token;
-            log.info('[UserContext] Token mis à jour, appel reloadUser');
+            const msg =
+              event === 'SIGNED_IN'
+                ? '[UserContext] Connexion détectée, appel reloadUser'
+                : '[UserContext] Token mis à jour, appel reloadUser';
+            log.info(msg);
             reloadUser();
           }
         } else if (event === 'SIGNED_OUT') {

--- a/frontend/src/contexts/UserContext.jsx
+++ b/frontend/src/contexts/UserContext.jsx
@@ -19,13 +19,21 @@ export const UserProvider = ({ children }) => {
     });
   }, []);
 
-  const reloadUser = useCallback(async () => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
+  const reloadUser = useCallback(async (currentSession) => {
+    let session = currentSession;
+    let user = currentSession?.user;
+
+    if (!session || !user) {
+      const {
+        data: { session: fetchedSession },
+      } = await supabase.auth.getSession();
+      const {
+        data: { user: fetchedUser },
+      } = await supabase.auth.getUser();
+      session = fetchedSession;
+      user = fetchedUser;
+    }
+
     if (!user || !session) return;
 
     console.trace('[TRACE] reloadUser appelé');
@@ -108,12 +116,12 @@ export const UserProvider = ({ children }) => {
         if (event === 'SIGNED_IN' && session) {
           tokenRef.current = session.access_token;
           log.info('[UserContext] Connexion détectée, appel reloadUser');
-          reloadUser();
+          reloadUser(session);
         } else if (event === 'TOKEN_REFRESHED' && session) {
           if (tokenRef.current !== session.access_token) {
             tokenRef.current = session.access_token;
             log.info('[UserContext] Token mis à jour, appel reloadUser');
-            reloadUser();
+            reloadUser(session);
           }
         } else if (event === 'SIGNED_OUT') {
           setUserInfo(null);

--- a/frontend/src/contexts/UserContext.jsx
+++ b/frontend/src/contexts/UserContext.jsx
@@ -36,6 +36,8 @@ export const UserProvider = ({ children }) => {
 
     if (!user || !session) return;
 
+    tokenRef.current = session.access_token;
+
     console.trace('[TRACE] reloadUser appelé');
 
     try {
@@ -113,13 +115,8 @@ export const UserProvider = ({ children }) => {
   useEffect(() => {
     const { data: listener } = supabase.auth.onAuthStateChange(
       (event, session) => {
-        if (event === 'SIGNED_IN' && session) {
-          tokenRef.current = session.access_token;
-          log.info('[UserContext] Connexion détectée, appel reloadUser');
-          reloadUser(session);
-        } else if (event === 'TOKEN_REFRESHED' && session) {
-          if (tokenRef.current !== session.access_token) {
-            tokenRef.current = session.access_token;
+        if (event === 'TOKEN_REFRESHED' && session) {
+          if (tokenRef.current && tokenRef.current !== session.access_token) {
             log.info('[UserContext] Token mis à jour, appel reloadUser');
             reloadUser(session);
           }

--- a/frontend/src/contexts/UserContext.jsx
+++ b/frontend/src/contexts/UserContext.jsx
@@ -105,7 +105,11 @@ export const UserProvider = ({ children }) => {
   useEffect(() => {
     const { data: listener } = supabase.auth.onAuthStateChange(
       (event, session) => {
-        if (event === 'TOKEN_REFRESHED' && session) {
+        if (event === 'SIGNED_IN' && session) {
+          tokenRef.current = session.access_token;
+          log.info('[UserContext] Connexion détectée, appel reloadUser');
+          reloadUser();
+        } else if (event === 'TOKEN_REFRESHED' && session) {
           if (tokenRef.current !== session.access_token) {
             tokenRef.current = session.access_token;
             log.info('[UserContext] Token mis à jour, appel reloadUser');

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams, useNavigate } from 'react-router-dom';
 import {
   GoogleHandleLogin,
   registerWithEmail,
@@ -34,6 +34,7 @@ function Auth() {
 
   const location = useLocation();
   const { lng } = useParams();
+  const navigate = useNavigate();
   const [redirect, setRedirect] = useState();
   useEffect(() => {
     const last = location.pathname.split('/').pop();
@@ -48,7 +49,7 @@ function Auth() {
   };
 
   const handleLogin = async () => {
-    const error = await loginWithEmail(email, password, redirect);
+    const error = await loginWithEmail(email, password);
     if (error) {
       setAlertMessage(
         '❌ ' + t(`supabase-error.${error.code || 'unexpected_error'}`)
@@ -61,6 +62,9 @@ function Auth() {
       origin: 'Auth.jsx',
       user: userInfo?.uid,
     });
+    navigate(
+      `/${lng}/auth/callback${redirect ? `?redirect=${encodeURIComponent(redirect)}` : ''}`
+    );
   };
 
   const handleRegister = async () => {

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -62,16 +62,10 @@ function Auth() {
       origin: 'Auth.jsx',
       user: userInfo?.uid,
     });
-    if (redirect) {
-      navigate(
-        redirect.startsWith('/') ? `/${lng}${redirect}` : redirect,
-        {
-          replace: true,
-        }
-      );
-    } else {
-      navigate(`/${lng}/calendars`, { replace: true });
-    }
+    const callbackUrl =
+      `/${lng}/auth/callback` +
+      (redirect ? `?redirect=${encodeURIComponent(redirect)}` : '');
+    navigate(callbackUrl, { replace: true });
   };
 
   const handleRegister = async () => {

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import {
   GoogleHandleLogin,
   registerWithEmail,
@@ -33,7 +33,6 @@ function Auth() {
   const [duration, setDuration] = useState(2000); // État pour la durée de l'alerte
 
   const location = useLocation();
-  const navigate = useNavigate();
   const { lng } = useParams();
   const [redirect, setRedirect] = useState();
   useEffect(() => {
@@ -62,11 +61,6 @@ function Auth() {
       origin: 'Auth.jsx',
       user: userInfo?.uid,
     });
-    if (redirect) {
-      navigate(redirect.startsWith('/') ? `/${lng}${redirect}` : redirect, {
-        replace: true,
-      });
-    }
   };
 
   const handleRegister = async () => {

--- a/frontend/src/pages/auth/Auth.jsx
+++ b/frontend/src/pages/auth/Auth.jsx
@@ -62,9 +62,16 @@ function Auth() {
       origin: 'Auth.jsx',
       user: userInfo?.uid,
     });
-    navigate(
-      `/${lng}/auth/callback${redirect ? `?redirect=${encodeURIComponent(redirect)}` : ''}`
-    );
+    if (redirect) {
+      navigate(
+        redirect.startsWith('/') ? `/${lng}${redirect}` : redirect,
+        {
+          replace: true,
+        }
+      );
+    } else {
+      navigate(`/${lng}/calendars`, { replace: true });
+    }
   };
 
   const handleRegister = async () => {

--- a/frontend/src/pages/auth/AuthCallback.jsx
+++ b/frontend/src/pages/auth/AuthCallback.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useContext, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '../../services/supabase/supabaseClient';
-import { UserContext } from '../../contexts/UserContext';
+import { getGlobalReloadUser, UserContext } from '../../contexts/UserContext';
 import { log } from '../../utils/logger';
 import { useTranslation } from 'react-i18next';
 import { getValidRedirect } from '../../utils/redirect';
@@ -12,6 +12,7 @@ const AuthCallback = () => {
   const { lng } = useParams();
   const { t } = useTranslation();
   const { userInfo } = useContext(UserContext);
+  const reloadUser = getGlobalReloadUser();
 
   // Pour stocker redirect et type entre les deux effets
   const redirectRef = useRef(null);
@@ -30,7 +31,7 @@ const AuthCallback = () => {
     redirectMap.get(String(rawType)) || '/calendars';
 
 
-  // 1) Vérifie la session
+  // 1) Vérifie la session et lance le reloadUser
   useEffect(() => {
     const handleRedirect = async () => {
       const search = new URLSearchParams(window.location.search);
@@ -52,6 +53,8 @@ const AuthCallback = () => {
       }
 
       const user = session.user;
+      reloadUser();
+
       log.info(t('auth_callback.success'), {
         origin: 'CALLBACK_SUCCESS',
         uid: user.id,
@@ -61,7 +64,7 @@ const AuthCallback = () => {
     };
 
     handleRedirect();
-  }, [navigate, t]);
+  }, [navigate, reloadUser, t]);
 
   // 2) Redirige quand userInfo est dispo
   useEffect(() => {

--- a/frontend/src/pages/auth/AuthCallback.jsx
+++ b/frontend/src/pages/auth/AuthCallback.jsx
@@ -53,7 +53,7 @@ const AuthCallback = () => {
       }
 
       const user = session.user;
-      reloadUser();
+      reloadUser(session);
 
       log.info(t('auth_callback.success'), {
         origin: 'CALLBACK_SUCCESS',

--- a/frontend/src/pages/auth/AuthCallback.jsx
+++ b/frontend/src/pages/auth/AuthCallback.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useContext, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '../../services/supabase/supabaseClient';
-import { getGlobalReloadUser, UserContext } from '../../contexts/UserContext';
+import { UserContext } from '../../contexts/UserContext';
 import { log } from '../../utils/logger';
 import { useTranslation } from 'react-i18next';
 import { getValidRedirect } from '../../utils/redirect';
@@ -10,7 +10,6 @@ import { getValidRedirect } from '../../utils/redirect';
 const AuthCallback = () => {
   const navigate = useNavigate();
   const { lng } = useParams();
-  const reloadUser = getGlobalReloadUser();
   const { t } = useTranslation();
   const { userInfo } = useContext(UserContext);
 
@@ -31,7 +30,7 @@ const AuthCallback = () => {
     redirectMap.get(String(rawType)) || '/calendars';
 
 
-  // 1) Vérifie la session et lance le reloadUser
+  // 1) Vérifie la session
   useEffect(() => {
     const handleRedirect = async () => {
       const search = new URLSearchParams(window.location.search);
@@ -53,8 +52,6 @@ const AuthCallback = () => {
       }
 
       const user = session.user;
-      reloadUser();
-
       log.info(t('auth_callback.success'), {
         origin: 'CALLBACK_SUCCESS',
         uid: user.id,
@@ -64,7 +61,7 @@ const AuthCallback = () => {
     };
 
     handleRedirect();
-  }, [navigate, reloadUser, t]);
+  }, [navigate, t]);
 
   // 2) Redirige quand userInfo est dispo
   useEffect(() => {

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -220,7 +220,7 @@ export const registerWithEmail = async (email, password, name, redirect) => {
 /**
  * Connexion avec email et mot de passe
  */
-export const loginWithEmail = async (email, password, redirect) => {
+export const loginWithEmail = async (email, password) => {
   try {
     const { error } = await supabase.auth.signInWithPassword({
       email,
@@ -234,7 +234,6 @@ export const loginWithEmail = async (email, password, redirect) => {
       return error;
     }
 
-    window.location.href = buildCallbackUrl(redirect);
     return null;
   } catch (error) {
     log.error('Erreur lors de la connexion avec email :', error.message, {

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -225,9 +225,6 @@ export const loginWithEmail = async (email, password, redirect) => {
     const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
-      options: {
-        redirectTo: buildCallbackUrl(redirect),
-      },
     });
     if (error) {
       log.error("Erreur lors de la connexion avec email :", error.message, error, {
@@ -236,6 +233,8 @@ export const loginWithEmail = async (email, password, redirect) => {
       });
       return error;
     }
+
+    window.location.href = buildCallbackUrl(redirect);
     return null;
   } catch (error) {
     log.error('Erreur lors de la connexion avec email :', error.message, {


### PR DESCRIPTION
## Summary
- redirect password login to callback handler instead of relying on Supabase redirect
- simplify Auth page login flow to rely on service redirect

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a374701a6483289937d9d2f7229808