### PR TITLE
Fix calendar sizing on mobile

### DIFF
--- a/frontend/src/components/ui/calendar.jsx
+++ b/frontend/src/components/ui/calendar.jsx
@@ -25,7 +25,7 @@ function Calendar({
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn(
-        "bg-background group/calendar p-3 [--cell-size:--spacing(8)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent",
+        "bg-background group/calendar p-3 [--cell-size:clamp(2.25rem,9vw,2.75rem)] sm:[--cell-size:--spacing(8)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent",
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className
@@ -37,7 +37,7 @@ function Calendar({
         ...formatters,
       }}
       classNames={{
-        root: cn("w-fit", defaultClassNames.root),
+        root: cn("w-full max-w-full", defaultClassNames.root),
         months: cn("flex gap-4 flex-col md:flex-row relative", defaultClassNames.months),
         month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
         nav: cn(


### PR DESCRIPTION
### Motivation
- The date picker had a fixed cell size which caused layout and usability issues on small/mobile screens.
- The goal is to make the calendar cells scale responsively so the date selector is usable on narrow viewports.

### Description
- Updated `frontend/src/components/ui/calendar.jsx` to use a responsive CSS variable by setting `--cell-size: clamp(2.25rem, 9vw, 2.75rem)` for small screens and fallback to the existing spacing on `sm` screens.
- Changed the calendar root container classes from `w-fit` to `w-full max-w-full` so the calendar can stretch to available width instead of being fixed.
- The change is localized to the `Calendar` component used with `react-day-picker` and only affects layout/CSS values.

### Testing
- No automated tests were executed for this change because it is a UI/layout-only modification.
- Recommend manual verification on mobile and responsive breakpoints to confirm sizing and layout improvements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fbdc0022c83288fd3cb85dc2e425e)