### PR TITLE
Sync week calendar selector view with selected date

### DIFF
--- a/frontend/src/components/calendar/WeekCalendarSelector.jsx
+++ b/frontend/src/components/calendar/WeekCalendarSelector.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Calendar } from '@/components/ui/calendar';
 import { getMondayDate } from '../../utils/calendar/dateUtils';
 import PropTypes from 'prop-types';
@@ -6,8 +6,18 @@ import { useTranslation } from 'react-i18next';
 import { getDateLocale } from '../../config/languages';
 
 export default function WeekCalendarSelector({ onWeekSelect, selectedDate }) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
   // Accept Date or ISO; normalize to Date for calendar operations
-  const selDate = selectedDate instanceof Date ? selectedDate : new Date(selectedDate);
+  const selDate = selectedDate
+    ? (selectedDate instanceof Date ? selectedDate : new Date(selectedDate))
+    : today;
+  const [month, setMonth] = useState(selDate);
+
+  useEffect(() => {
+    setMonth(selDate);
+  }, [selDate]);
+
   const mondayDate = getMondayDate(selDate);
   const weekDates = [...Array(7)].map((_, i) => {
     const d = new Date(mondayDate);
@@ -15,12 +25,11 @@ export default function WeekCalendarSelector({ onWeekSelect, selectedDate }) {
     d.setHours(0,0,0,0);
     return d;
   });
-  const today = new Date();
-  today.setHours(0,0,0,0);
   const { i18n } = useTranslation();
 
   const handleSelect = (date) => {
     if (date) {
+      setMonth(date);
       onWeekSelect(date);
     }
   };
@@ -30,6 +39,8 @@ export default function WeekCalendarSelector({ onWeekSelect, selectedDate }) {
       mode="single"
       selected={selDate || today}
       onSelect={handleSelect}
+      month={month}
+      onMonthChange={setMonth}
       locale={getDateLocale(i18n.language)}
       modifiers={{
         weekSelected: weekDates


### PR DESCRIPTION
### Motivation
- Fix the week/date selector so the calendar always jumps to the page containing the selected date instead of showing the chosen week off-screen.
- Prevent the UI bug where the selected dates appear below or outside the currently displayed month view.

### Description
- Normalize `selectedDate` to a Date and default to today when missing in `frontend/src/components/calendar/WeekCalendarSelector.jsx`.
- Add local state `month` and `setMonth` and sync it with `selDate` using `useEffect` to keep the calendar view aligned with the selected date.
- Pass `month` and `onMonthChange={setMonth}` to the `Calendar` component and call `setMonth(date)` inside the date selection handler to force the picker to the correct page.
- Small cleanup of `today` normalization and selection handling to ensure consistent midnight-normalized dates.

### Testing
- Installed dependencies with `npm install` in `frontend` and the install completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (server started successfully).
- Captured a UI screenshot using a Playwright script to validate the calendar UI rendering and navigation, and the script completed successfully.
- No unit/integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc0e17964832894057116b6f65653)