### PR TITLE
Add calendar layout classNames to WeekCalendarSelector

### DIFF
--- a/frontend/src/components/calendar/WeekCalendarSelector.jsx
+++ b/frontend/src/components/calendar/WeekCalendarSelector.jsx
@@ -35,13 +35,21 @@ export default function WeekCalendarSelector({ onWeekSelect, selectedDate }) {
       onSelect={handleSelect}
       locale={getDateLocale(i18n.language)}
       showOutsideDays
+      className="relative overflow-hidden border rounded-lg w-full"
+      classNames={{
+        months: "flex flex-col",
+        month: "space-y-4",
+        table: "w-full border-collapse",
+        tbody: "relative",
+        cell: "relative p-0 text-center",
+        day: "h-9 w-9 rounded-md",
+      }}
       modifiers={{
         weekSelected: weekDates
       }}
       modifiersClassNames={{
         weekSelected: 'bg-primary text-primary-foreground hover:bg-primary/90 data-[selected=true]:bg-primary rounded-md'
       }}
-      className="border rounded-lg w-full"
     />
   );
 }


### PR DESCRIPTION
### Motivation
- Ensure the `Calendar` in `WeekCalendarSelector` renders with consistent sizing and layout across contexts.
- Apply overflow handling and border/rounding styles to prevent layout issues in constrained containers.
- Allow overriding DayPicker defaults via `classNames` so internal elements match the app's utility classes.
- Preserve existing selection behavior while adding these visual/layout fixes.

### Description
- Updated the `Calendar` invocation in `frontend/src/components/calendar/WeekCalendarSelector.jsx` to include a `className` of `relative overflow-hidden border rounded-lg w-full`.
- Added a `classNames` prop mapping for `months`, `month`, `table`, `tbody`, `cell`, and `day` to control internal DayPicker layout and sizing.
- Retained existing props such as `mode`, `selected`, `onSelect`, `locale`, `showOutsideDays`, and `modifiers` to preserve behavior.
- No other files were modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950197c2b988328b1372b105cdded56)