### PR TITLE
Fix shared calendar row wrapping on mobile

### DIFF
--- a/frontend/src/pages/calendars/CalendarList.jsx
+++ b/frontend/src/pages/calendars/CalendarList.jsx
@@ -282,7 +282,7 @@ function SelectCalendar({
               (calendarData, index) => (
                 <div key={index} className="border-b last:border-b-0 p-3 hover:bg-accent/50 transition">
 
-                  <div className="flex justify-between items-center gap-3">
+                  <div className="flex flex-wrap justify-between items-center gap-3">
                     <div className="grow">
                       <h5 className="font-semibold text-lg mb-1">{calendarData.name}</h5>
                       <div className="text-sm text-muted-foreground">


### PR DESCRIPTION
### Motivation
- The "Shared calendars" row used a `flex` container without wrapping which caused action buttons to overflow and be clipped on small screens.
- The parent container uses `overflow-hidden`, resulting in a large empty block when elements couldn't fit on one line.
- The intent is to match the behavior of the personal calendars list so actions can wrap onto a new line on mobile.

### Description
- Added `flex-wrap` to the shared calendar row container in `frontend/src/pages/calendars/CalendarList.jsx` to allow actions to wrap.
- This is a one-line layout change that aligns the shared calendars list with the existing personal calendars behavior.
- No functional logic was changed, only layout/CSS class adjustments.

### Testing
- Ran `npm install` in `frontend` which completed successfully and reported no vulnerabilities.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready.
- Executed a Playwright script that opened `/en/calendars` at a mobile viewport and produced a screenshot `artifacts/calendars-mobile.png` to verify the layout change.
- No unit or automated integration tests were modified or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516aaf516c8328a166990e42715a58)